### PR TITLE
Add PlatformIO support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,20 @@ This repository hosts ESP32 compatible driver for OV2640 and OV3660 image sensor
 - Enable PSRAM in `menuconfig`
 - Include `esp_camera.h` in your code
 
+## PlatformIO
+
+Ths library is currently NOT registered with PlatformIO Library Manager,
+but can be installed directly from the Git repository using
+
+-     lib_deps =
+        https://github.com/espressif/esp32-camera
+
+from your platformio.ini file, or
+
+-     platformio lib install https://github.com/espressif/esp32-camera
+
+from the PlatformIO terminal
+
 ## Examples
 
 ### Initialization

--- a/library.json
+++ b/library.json
@@ -16,6 +16,9 @@
         "url": "https://github.com/Mnark/esp32-camera.git",
         "branch": "master"
     },
+    "export": {
+        "exclude": "library.json"
+    },
     "frameworks": "espidf",
     "platforms": "*"
 }

--- a/library.json
+++ b/library.json
@@ -14,7 +14,8 @@
     "dependencies": {},
     "repository": {
         "type": "git",
-        "url": "https://github.com/espressif/esp32-camera"
+        "url": "https://github.com/espressif/esp32-camera",
+        "branch": "master"
     },
     "frameworks": "espidf",
     "platforms": "*"

--- a/library.json
+++ b/library.json
@@ -13,7 +13,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/Mnark/esp32-camera.git",
+        "url": "git+git://github.com/Mnark/esp32-camera.git",
         "branch": "master"
     },
     "frameworks": "espidf",

--- a/library.json
+++ b/library.json
@@ -12,7 +12,10 @@
         ]
     },
     "dependencies": {},
-    "version": "0.0.1",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/espressif/esp32-camera"
+    },
     "frameworks": "espidf",
     "platforms": "*"
 }

--- a/library.json
+++ b/library.json
@@ -14,7 +14,7 @@
     "dependencies": {},
     "repository": {
         "type": "git",
-        "url": "https://github.com/Mnark/esp32-camera",
+        "url": "https://github.com/Mnark/esp32-camera.git",
         "branch": "master"
     },
     "frameworks": "espidf",

--- a/library.json
+++ b/library.json
@@ -13,7 +13,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+git://github.com/Mnark/esp32-camera.git",
+        "url": "https://github.com/Mnark/esp32-camera.git",
         "branch": "master"
     },
     "frameworks": "espidf",

--- a/library.json
+++ b/library.json
@@ -1,17 +1,16 @@
 {
     "name": "esp32-camera",
-    "keywords": "esp32, camera",
-    "description": "esp32-camera",
-    "authors": [
-        {
-            "name": "Expressif"
-        }
-    ],
-
+    "keywords": "esp32, camera, espressif",
+    "description": "ESP32 compatible driver for OV2640 and OV3660 image sensors.",
     "build": {
-        "flags": "-Idriver/include -Idriver/private_include -Iconversions/include -Iconversions/private_include -Isensors/private_include"
+        "flags": [
+            "-Idriver/include",
+            "-Idriver/private_include",
+            "-Iconversions/include",
+            "-Iconversions/private_include",
+            "-Isensors/private_include"
+        ]
     },
-
     "dependencies": {},
     "version": "0.0.1",
     "frameworks": "espidf",

--- a/library.json
+++ b/library.json
@@ -1,0 +1,19 @@
+{
+    "name": "esp32-camera",
+    "keywords": "esp32, camera",
+    "description": "esp32-camera",
+    "authors": [
+        {
+            "name": "Expressif"
+        }
+    ],
+
+    "build": {
+        "flags": "-Idriver/include -Idriver/private_include -Iconversions/include -Iconversions/private_include -Isensors/private_include"
+    },
+
+    "dependencies": {},
+    "version": "0.0.1",
+    "frameworks": "espidf",
+    "platforms": "*"
+}

--- a/library.json
+++ b/library.json
@@ -14,7 +14,7 @@
     "dependencies": {},
     "repository": {
         "type": "git",
-        "url": "https://github.com/espressif/esp32-camera",
+        "url": "https://github.com/Mnark/esp32-camera",
         "branch": "master"
     },
     "frameworks": "espidf",

--- a/library.json
+++ b/library.json
@@ -11,7 +11,6 @@
             "-Isensors/private_include"
         ]
     },
-    "dependencies": {},
     "repository": {
         "type": "git",
         "url": "https://github.com/Mnark/esp32-camera.git",


### PR DESCRIPTION
These changes make it possible to install the library into PlatformIO.

I have left the version at 0.0.1, but I think this should be kept inline with the library version.