### PR TITLE
Feature: persistent storage of sensor settings in nvs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,6 @@ set(COMPONENT_PRIV_INCLUDEDIRS
   )
 
 set(COMPONENT_REQUIRES driver)
-set(COMPONENT_PRIV_REQUIRES freertos)
+set(COMPONENT_PRIV_REQUIRES freertos nvs_flash)
 
 register_component()

--- a/driver/camera.c
+++ b/driver/camera.c
@@ -1391,7 +1391,7 @@ esp_err_t esp_camera_load_from_nvs(const char *key)
       if (s != NULL) {
           size_t size = sizeof(camera_status_t);
           ret = nvs_get_blob(handle,CAMERA_SENSOR_NVS_KEY,&st,&size);
-          if (ret = ESP_OK) {
+          if (ret == ESP_OK) {
             s->set_ae_level(s,st.ae_level);
             s->set_aec2(s,st.aec2);
             s->set_aec_value(s,st.aec_value);

--- a/driver/camera.c
+++ b/driver/camera.c
@@ -29,6 +29,8 @@
 #include "driver/rtc_io.h"
 #include "driver/periph_ctrl.h"
 #include "esp_intr_alloc.h"
+#include "nvs_flash.h"
+#include "nvs.h"
 #include "sensor.h"
 #include "sccb.h"
 #include "esp_camera.h"
@@ -67,6 +69,7 @@ typedef enum {
 #include "esp_log.h"
 static const char* TAG = "camera";
 #endif
+static const char* CAMERA_SENSOR_NVS_KEY = "sensor";
 
 typedef void (*dma_filter_t)(const dma_elem_t* src, lldesc_t* dma_desc, uint8_t* dst);
 
@@ -1353,4 +1356,76 @@ sensor_t * esp_camera_sensor_get()
         return NULL;
     }
     return &s_state->sensor;
+}
+
+esp_err_t esp_camera_save_to_nvs(const char *key) 
+{
+    nvs_handle_t handle;
+    
+    esp_err_t ret = nvs_open(key,NVS_READWRITE,&handle);
+    
+    if (ret == ESP_OK) {
+        sensor_t *s = esp_camera_sensor_get();
+        if (s != NULL) {
+            ret = nvs_set_blob(handle,CAMERA_SENSOR_NVS_KEY,&s->status,sizeof(camera_status_t));
+            return ret;
+        } else {
+            return ESP_ERR_CAMERA_NOT_DETECTED; 
+        }
+        nvs_close(handle);
+        return ret;
+    } else {
+        return ret;
+    }
+}
+
+esp_err_t esp_camera_load_from_nvs(const char *key) 
+{
+  nvs_handle_t handle;
+  
+  esp_err_t ret = nvs_open(key,NVS_READWRITE,&handle);
+  
+  if (ret == ESP_OK) {
+      sensor_t *s = esp_camera_sensor_get();
+      camera_status_t st;
+      if (s != NULL) {
+          size_t size = sizeof(camera_status_t);
+          ret = nvs_get_blob(handle,CAMERA_SENSOR_NVS_KEY,&st,&size);
+          if (ret = ESP_OK) {
+            s->set_ae_level(s,st.ae_level);
+            s->set_aec2(s,st.aec2);
+            s->set_aec_value(s,st.aec_value);
+            s->set_agc_gain(s,st.agc_gain);
+            s->set_awb_gain(s,st.awb_gain);
+            s->set_bpc(s,st.bpc);
+            s->set_brightness(s,st.brightness);
+            s->set_colorbar(s,st.colorbar);
+            s->set_contrast(s,st.contrast);
+            s->set_dcw(s,st.dcw);
+            s->set_denoise(s,st.denoise);
+            s->set_exposure_ctrl(s,st.aec);
+            s->set_framesize(s,st.framesize);
+            s->set_gain_ctrl(s,st.agc);          
+            s->set_gainceiling(s,st.gainceiling);
+            s->set_hmirror(s,st.hmirror);
+            s->set_lenc(s,st.lenc);
+            s->set_quality(s,st.quality);
+            s->set_raw_gma(s,st.raw_gma);
+            s->set_saturation(s,st.saturation);
+            s->set_sharpness(s,st.sharpness);
+            s->set_special_effect(s,st.special_effect);
+            s->set_vflip(s,st.vflip);
+            s->set_wb_mode(s,st.wb_mode);
+            s->set_whitebal(s,st.awb);
+            s->set_wpc(s,st.wpc);
+          }  
+      } else {
+          return ESP_ERR_CAMERA_NOT_DETECTED;
+      }
+      nvs_close(handle);
+      return ret;
+  } else {
+      ESP_LOGW(TAG,"Error (%d) opening nvs key \"%s\"",ret,key);
+      return ret;
+  }
 }

--- a/driver/include/esp_camera.h
+++ b/driver/include/esp_camera.h
@@ -171,6 +171,19 @@ void esp_camera_fb_return(camera_fb_t * fb);
  */
 sensor_t * esp_camera_sensor_get();
 
+/**
+ * @brief Save camera settings to non-volatile-storage (NVS)
+ * 
+ * @param key   A unique nvs key name for the camera settings 
+ */
+esp_err_t esp_camera_save_to_nvs(const char *key);
+
+/**
+ * @brief Save camera settings to non-volatile-storage (NVS)
+ * 
+ * @param key   A unique nvs key name for the camera settings 
+ */
+esp_err_t esp_camera_load_from_nvs(const char *key);
 
 #ifdef __cplusplus
 }

--- a/driver/include/esp_camera.h
+++ b/driver/include/esp_camera.h
@@ -179,7 +179,7 @@ sensor_t * esp_camera_sensor_get();
 esp_err_t esp_camera_save_to_nvs(const char *key);
 
 /**
- * @brief Save camera settings to non-volatile-storage (NVS)
+ * @brief Load camera settings from non-volatile-storage (NVS)
  * 
  * @param key   A unique nvs key name for the camera settings 
  */


### PR DESCRIPTION
Add two new functions to esp_camera.h to assist in persistent camera settings in nvs. It would be useful to have changes to camera settings persist across reboots:
```
esp_err_t esp_camera_save_to_nvs(const char *key);
esp_err_t esp_camera_load_from_nvs(const char *key);
```
key is a unique name for the camera settings. It is possible to save different camera setting "profiles" by using different key names (which might be handy for say a day/night mode).

Both functions load/save a `camera_settings_t` structure to the nvs data partition as a blob. 

When loading the structure from the nvs, each individual setting has to be written using the sensor_t->set_xxx(s,value) methods or the setting won't be sent to the camera sensor.

I did consider writing each field to the nvs data store individually but decided it was a waste of space to do so. But writing them individually would ensure that changes to the structure of camera_settings_t wouldn't invalidate all stored settings.