### PR TITLE
fixed clock config to explicitly use APB

### DIFF
--- a/driver/xclk.c
+++ b/driver/xclk.c
@@ -20,6 +20,7 @@ esp_err_t camera_enable_out_clock(camera_config_t* config)
     timer_conf.freq_hz = config->xclk_freq_hz;
     timer_conf.speed_mode = LEDC_HIGH_SPEED_MODE;
     timer_conf.timer_num = config->ledc_timer;
+    timer_conf.clk_cfg = LEDC_USE_APB_CLK;
     esp_err_t err = ledc_timer_config(&timer_conf);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "ledc_timer_config failed, rc=%x", err);

--- a/driver/xclk.c
+++ b/driver/xclk.c
@@ -20,7 +20,7 @@ esp_err_t camera_enable_out_clock(camera_config_t* config)
     timer_conf.freq_hz = config->xclk_freq_hz;
     timer_conf.speed_mode = LEDC_HIGH_SPEED_MODE;
     timer_conf.timer_num = config->ledc_timer;
-    timer_conf.clk_cfg = LEDC_USE_APB_CLK;
+	timer_conf.clk_cfg = LEDC_AUTO_CLK;
     esp_err_t err = ledc_timer_config(&timer_conf);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "ledc_timer_config failed, rc=%x", err);


### PR DESCRIPTION
in commit 2e8c85d8fff823232af46cc0f353ac170d0971e9 of esp-idf the ledc.c driver was changed and it no longer assumes APB clock use and it needs to be set explicitly