### PR TITLE
Move _STREAM_BOUNDARY before _STREAM_PART

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,15 +213,15 @@ esp_err_t jpg_stream_httpd_handler(httpd_req_t *req){
             }
         }
         if(res == ESP_OK){
+            res = httpd_resp_send_chunk(req, _STREAM_BOUNDARY, strlen(_STREAM_BOUNDARY));
+        }
+        if(res == ESP_OK){
             size_t hlen = snprintf((char *)part_buf, 64, _STREAM_PART, _jpg_buf_len);
 
             res = httpd_resp_send_chunk(req, (const char *)part_buf, hlen);
         }
         if(res == ESP_OK){
             res = httpd_resp_send_chunk(req, (const char *)_jpg_buf, _jpg_buf_len);
-        }
-        if(res == ESP_OK){
-            res = httpd_resp_send_chunk(req, _STREAM_BOUNDARY, strlen(_STREAM_BOUNDARY));
         }
         if(fb->format != PIXFORMAT_JPEG){
             free(_jpg_buf);


### PR DESCRIPTION
The boundary delimiter (`_STREAM_BOUNDARY`) needs to be send before the
body part (`_STREAM_PART`) too follow RFC2046. This caused `ffplay`/`ffmpeg`
to fail to open the MJPEG stream.

See also PR [espressif/arduino-esp32/pull/3720](https://github.com/espressif/arduino-esp32/pull/3720).