### PR TITLE
Search for available interrupts

### DIFF
--- a/driver/camera.c
+++ b/driver/camera.c
@@ -447,9 +447,27 @@ static void i2s_init()
     I2S0.timing.rx_dsync_sw = 1;
 
     // Allocate I2S interrupt, keep it disabled
-    esp_intr_alloc(ETS_I2S0_INTR_SOURCE,
-                   ESP_INTR_FLAG_INTRDISABLED | ESP_INTR_FLAG_LEVEL1 | ESP_INTR_FLAG_IRAM,
-                   &i2s_isr, NULL, &s_state->i2s_intr_handle);
+    esp_err_t ret;
+    for (int i = 1; i <= 3; i++)
+    {
+        int level = 1<<i; // accept a Level <i> interrupt vector, see ESP_INTR_FLAG_LEVEL1
+
+        ret = esp_intr_alloc(ETS_I2S0_INTR_SOURCE,
+                    ESP_INTR_FLAG_INTRDISABLED | ESP_INTR_FLAG_IRAM | level,
+                    &i2s_isr, NULL, &s_state->i2s_intr_handle);
+
+        if (ret == ESP_OK)
+        {
+            break;
+        }
+        else if (ret == ESP_ERR_NOT_FOUND)
+        {
+            ESP_LOGD(TAG, "No free interrupt found on CPU with level %d", i);
+            continue;
+        }
+    }
+
+    ESP_ERROR_CHECK(ret);    
 }
 
 static void IRAM_ATTR i2s_start_bus()


### PR DESCRIPTION
When combining the ESP-CAM with other interrupt enabled devices, e.g. SPI, there might not be enough level 1 interrupts available. This code cycles through levels 1 to 3 to see if an interrupt is available.