### PR TITLE
don't need that header, be careful the name is different in idf 4+ and 4-

### DIFF
--- a/conversions/to_bmp.c
+++ b/conversions/to_bmp.c
@@ -14,7 +14,6 @@
 #include <stddef.h>
 #include <string.h>
 #include "img_converters.h"
-#include "esp_spiram.h"
 #include "soc/efuse_reg.h"
 #include "esp_heap_caps.h"
 #include "yuv.h"


### PR DESCRIPTION
esp_spiram.h before 4.0
esp32/spiram.h on 4.0