### PR TITLE
Port it as a library on PlatformIO

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## General Information
 
-This repository hosts ESP32 compatible driver for OV2640 and OV3660 image sensors. Additionally it provides a few tools, which allow converting the captured frame data to the more common BMP and JPEG formats.
+This repository hosts ESP32 compatible driver for OV2640, OV3660, OV5640 and OV7725 image sensors. Additionally it provides a few tools, which allow converting the captured frame data to the more common BMP and JPEG formats.
 
 ## Important to Remember
 
@@ -13,9 +13,48 @@ This repository hosts ESP32 compatible driver for OV2640 and OV3660 image sensor
 
 ## Installation Instructions
 
+
+### Using esp-idf
+
 - Clone or download and extract the repository to the components folder of your ESP-IDF project
 - Enable PSRAM in `menuconfig`
 - Include `esp_camera.h` in your code
+
+### Using PlatformIO
+
+On the `env` section of `platformio.ini`, add the following:
+
+```ini
+[env]
+lib_deps =
+  esp32-camera
+```
+
+Now the `esp_camera.h` is available to be included:
+
+```c
+#include "esp_camera.h"
+```
+
+Enable PSRAM on `menuconfig` or type it direclty on `sdkconfig`. Check the [official doc](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/kconfig.html#config-esp32-spiram-support) for more info.
+
+```
+CONFIG_ESP32_SPIRAM_SUPPORT=y
+```
+
+**Make sure to append** [this `Kconfig`](./Kconfig) content into the `Kconfig` of your project. Then, choose the configurations according to your setup.
+
+### Kconfig options
+
+| config                            | description                                                                                                                                                  | default                        |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------ |
+| CONFIG_OV2640_SUPPORT             | Support for OV2640 camera                                                                                                                                    | enabled                        |
+| CONFIG_OV7725_SUPPORT             | Support for OV7725 camera                                                                                                                                    | disabled                       |
+| CONFIG_OV3660_SUPPORT             | Support for OV3660 camera                                                                                                                                    | enabled                        |
+| CONFIG_OV5640_SUPPORT             | Support for OV5640 camera                                                                                                                                    | enabled                        |
+| CONFIG_SCCB_HARDWARE_I2C          | Enable this option if you want to use hardware I2C to control the camera. Disable this option to use software I2C.                                           | enabled                        |
+| CONFIG_SCCB_HARDWARE_I2C_PORT     | I2C peripheral to use for SCCB. Can be I2C0 and I2C1.                                                                                                        | CONFIG_SCCB_HARDWARE_I2C_PORT1 |
+| CONFIG_CAMERA_TASK_PINNED_TO_CORE | Pin the camera handle task to a certain core(0/1). It can also be done automatically choosing NO_AFFINITY. Can be CAMERA_CORE0, CAMERA_CORE1 or NO_AFFINITY. | CONFIG_CAMERA_CORE0            |
 
 ## Examples
 
@@ -283,3 +322,6 @@ esp_err_t bmp_httpd_handler(httpd_req_t *req){
     return res;
 }
 ```
+
+
+

--- a/examples/take_picture.c
+++ b/examples/take_picture.c
@@ -1,0 +1,150 @@
+/**
+ * This example takes a picture every 5s and print its size on serial monitor.
+ */
+
+// =============================== SETUP ======================================
+
+// 1. Board setup (Uncomment):
+// #define BOARD_WROVER_KIT
+// #define BOARD_ESP32CAM_AITHINKER
+
+/**
+ * 2. Kconfig setup
+ * 
+ * If you have a Kconfig file, copy the content from
+ *  https://github.com/espressif/esp32-camera/blob/master/Kconfig into it.
+ * In case you haven't, copy and paste this Kconfig file inside the src directory.
+ * This Kconfig file has definitions that allows more control over the camera and
+ * how it will be initialized.
+ */
+
+/**
+ * 3. Enable PSRAM on sdkconfig:
+ * 
+ * CONFIG_ESP32_SPIRAM_SUPPORT=y
+ * 
+ * More info on
+ * https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/kconfig.html#config-esp32-spiram-support
+ */
+
+// ================================ CODE ======================================
+
+#include <esp_event_loop.h>
+#include <esp_log.h>
+#include <esp_system.h>
+#include <nvs_flash.h>
+#include <sys/param.h>
+#include <string.h>
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+#include "esp_camera.h"
+
+// WROVER-KIT PIN Map
+#ifdef BOARD_WROVER_KIT
+
+#define CAM_PIN_PWDN -1  //power down is not used
+#define CAM_PIN_RESET -1 //software reset will be performed
+#define CAM_PIN_XCLK 21
+#define CAM_PIN_SIOD 26
+#define CAM_PIN_SIOC 27
+
+#define CAM_PIN_D7 35
+#define CAM_PIN_D6 34
+#define CAM_PIN_D5 39
+#define CAM_PIN_D4 36
+#define CAM_PIN_D3 19
+#define CAM_PIN_D2 18
+#define CAM_PIN_D1 5
+#define CAM_PIN_D0 4
+#define CAM_PIN_VSYNC 25
+#define CAM_PIN_HREF 23
+#define CAM_PIN_PCLK 22
+
+#endif
+
+// ESP32Cam (AiThinker) PIN Map
+#ifdef BOARD_ESP32CAM_AITHINKER
+
+#define CAM_PIN_PWDN 32
+#define CAM_PIN_RESET -1 //software reset will be performed
+#define CAM_PIN_XCLK 0
+#define CAM_PIN_SIOD 26
+#define CAM_PIN_SIOC 27
+
+#define CAM_PIN_D7 35
+#define CAM_PIN_D6 34
+#define CAM_PIN_D5 39
+#define CAM_PIN_D4 36
+#define CAM_PIN_D3 21
+#define CAM_PIN_D2 19
+#define CAM_PIN_D1 18
+#define CAM_PIN_D0 5
+#define CAM_PIN_VSYNC 25
+#define CAM_PIN_HREF 23
+#define CAM_PIN_PCLK 22
+
+#endif
+
+static const char *TAG = "example:take_picture";
+
+static camera_config_t camera_config = {
+    .pin_pwdn = CAM_PIN_PWDN,
+    .pin_reset = CAM_PIN_RESET,
+    .pin_xclk = CAM_PIN_XCLK,
+    .pin_sscb_sda = CAM_PIN_SIOD,
+    .pin_sscb_scl = CAM_PIN_SIOC,
+
+    .pin_d7 = CAM_PIN_D7,
+    .pin_d6 = CAM_PIN_D6,
+    .pin_d5 = CAM_PIN_D5,
+    .pin_d4 = CAM_PIN_D4,
+    .pin_d3 = CAM_PIN_D3,
+    .pin_d2 = CAM_PIN_D2,
+    .pin_d1 = CAM_PIN_D1,
+    .pin_d0 = CAM_PIN_D0,
+    .pin_vsync = CAM_PIN_VSYNC,
+    .pin_href = CAM_PIN_HREF,
+    .pin_pclk = CAM_PIN_PCLK,
+
+    //XCLK 20MHz or 10MHz for OV2640 double FPS (Experimental)
+    .xclk_freq_hz = 20000000,
+    .ledc_timer = LEDC_TIMER_0,
+    .ledc_channel = LEDC_CHANNEL_0,
+
+    .pixel_format = PIXFORMAT_JPEG, //YUV422,GRAYSCALE,RGB565,JPEG
+    .frame_size = FRAMESIZE_VGA,    //QQVGA-UXGA Do not use sizes above QVGA when not JPEG
+
+    .jpeg_quality = 12, //0-63 lower number means higher quality
+    .fb_count = 1       //if more than one, i2s runs in continuous mode. Use only with JPEG
+};
+
+static esp_err_t init_camera()
+{
+    //initialize the camera
+    esp_err_t err = esp_camera_init(&camera_config);
+    if (err != ESP_OK)
+    {
+        ESP_LOGE(TAG, "Camera Init Failed");
+        return err;
+    }
+
+    return ESP_OK;
+}
+
+void app_main()
+{
+    init_camera();
+
+    while (1)
+    {
+        ESP_LOGI(TAG, "Taking picture...");
+        camera_fb_t *pic = esp_camera_fb_get();
+
+        // use pic->buf to access the image
+        ESP_LOGI(TAG, "Picture taken! Its size was: %zu bytes", pic->len);
+
+        vTaskDelay(5000 / portTICK_RATE_MS);
+    }
+}

--- a/library.json
+++ b/library.json
@@ -1,0 +1,25 @@
+{
+  "name": "esp32-camera",
+  "version": "1.0.0",
+  "keywords": "esp32, camera, espressif, esp32-cam",
+  "description": "ESP32 compatible driver for OV2640, OV3660, OV5640 and OV7725 image sensors.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/espressif/esp32-camera"
+  },
+  "frameworks": "espidf",
+  "platforms": "*",
+  "build": {
+    "flags": [
+      "-Idriver/include",
+      "-Iconversions/include",
+      "-Idriver/private_include",
+      "-Iconversions/private_include",
+      "-Isensors/private_include",
+      "-fno-rtti"
+    ],
+    "includeDir": ".",
+    "srcDir": ".",
+    "srcFilter": ["-<*>", "+<driver>", "+<conversions>", "+<sensors>"]
+  }
+}


### PR DESCRIPTION
# Description

This PR adds `library.json` to make this compatible with PlatformIO library ([docs on how to create a library](https://docs.platformio.org/en/latest/librarymanager/creating.html)).

It also adds an example to be shown on the library page and updates README to include the setup with PlatformIO.

## Attachments

- Using the library [`esp32-camera`](https://platformio.org/lib/show/10785/esp32-camera) to build for AI-Thinker board.
![using with platformio](https://user-images.githubusercontent.com/11169832/87800100-5fcefd00-c824-11ea-8445-887de71cc3ac.gif)
