### PR TITLE
Bugfix: initialize i2c_config_t struct to zero

### DIFF
--- a/driver/sccb.c
+++ b/driver/sccb.c
@@ -41,7 +41,8 @@ int SCCB_Init(int pin_sda, int pin_scl)
 {
     ESP_LOGI(TAG, "pin_sda %d pin_scl %d\n", pin_sda, pin_scl);
     //log_i("SCCB_Init start");
-    i2c_config_t conf = {};
+    i2c_config_t conf;
+    memset(&conf, 0, sizeof(i2c_config_t));
     conf.mode = I2C_MODE_MASTER;
     conf.sda_io_num = pin_sda;
     conf.sda_pullup_en = GPIO_PULLUP_ENABLE;

--- a/driver/sccb.c
+++ b/driver/sccb.c
@@ -41,7 +41,7 @@ int SCCB_Init(int pin_sda, int pin_scl)
 {
     ESP_LOGI(TAG, "pin_sda %d pin_scl %d\n", pin_sda, pin_scl);
     //log_i("SCCB_Init start");
-    i2c_config_t conf;
+    i2c_config_t conf = {};
     conf.mode = I2C_MODE_MASTER;
     conf.sda_io_num = pin_sda;
     conf.sda_pullup_en = GPIO_PULLUP_ENABLE;


### PR DESCRIPTION
In some cases, initialization fails because some flags are not set to zero