### PR TITLE
SCCB_Probe() improved

### DIFF
--- a/driver/private_include/sccb.h
+++ b/driver/private_include/sccb.h
@@ -9,7 +9,7 @@
 #ifndef __SCCB_H__
 #define __SCCB_H__
 #include <stdint.h>
-int SCCB_Init(int pin_sda, int pin_scl);
+int     SCCB_Init(int pin_sda, int pin_scl);
 uint8_t SCCB_Probe();
 uint8_t SCCB_Read(uint8_t slv_addr, uint8_t reg);
 uint8_t SCCB_Write(uint8_t slv_addr, uint8_t reg, uint8_t data);


### PR DESCRIPTION
- speed up camera detection
- avoid wrong port detection if there are any other devices (like PCF8583, PCF8574 etc.) on the same I2C bus
- leave other I2C devices (if any) on the same I2C bus untouched
