### PR TITLE
Fix "gpio_install_isr_service failed (105)" error.

### DIFF
--- a/driver/camera.c
+++ b/driver/camera.c
@@ -1321,7 +1321,7 @@ esp_err_t camera_init(const camera_config_t* config)
     }
 
     vsync_intr_disable();
-    err = gpio_install_isr_service(ESP_INTR_FLAG_LEVEL1 | ESP_INTR_FLAG_IRAM);
+    err = gpio_install_isr_service(ESP_INTR_FLAG_LOWMED | ESP_INTR_FLAG_IRAM);
     if (err != ESP_OK) {
     	if (err != ESP_ERR_INVALID_STATE) {
     		ESP_LOGE(TAG, "gpio_install_isr_service failed (%x)", err);


### PR DESCRIPTION
The error occurs during the camera initialization. The modification in the pull request solved the error, however, I am not sure the if the modification introduces other defects.