### PR TITLE
bugfix: fix tjpgd configuration for esp32s2

### DIFF
--- a/target/esp32s2/private_include/tjpgd.h
+++ b/target/esp32s2/private_include/tjpgd.h
@@ -7,7 +7,7 @@
 /* System Configurations */
 
 #define	JD_SZBUF		512	/* Size of stream input buffer */
-#define JD_FORMAT		1	/* Output pixel format 0:RGB888 (3 BYTE/pix), 1:RGB565 (1 WORD/pix) */
+#define JD_FORMAT		0	/* Output pixel format 0:RGB888 (3 BYTE/pix), 1:RGB565 (1 WORD/pix) */
 #define	JD_USE_SCALE	1	/* Use descaling feature for output */
 #define JD_TBLCLIP		1	/* Use table for saturation (might be a bit faster but increases 1K bytes of code size) */
 


### PR DESCRIPTION
# Changes

- modify tjpgd output pixel format to RGB888