### PR TITLE
Added missing library.json build flag

### DIFF
--- a/library.json
+++ b/library.json
@@ -16,6 +16,7 @@
       "-Idriver/private_include",
       "-Iconversions/private_include",
       "-Isensors/private_include",
+      "-Itarget/private_include",
       "-fno-rtti"
     ],
     "includeDir": ".",


### PR DESCRIPTION
Project using this library wouldn't compile with this error:
.pio/libdeps/esp32cam/esp32-camera/driver/cam_hal.c:18:10: fatal error: ll_cam.h: No such file or directory
Adding this line seems to fix it.