### PR TITLE
Fix wrong return code when nvs_get_blob failed

### DIFF
--- a/driver/camera.c
+++ b/driver/camera.c
@@ -1575,7 +1575,10 @@ esp_err_t esp_camera_load_from_nvs(const char *key)
             s->set_wb_mode(s,st.wb_mode);
             s->set_whitebal(s,st.awb);
             s->set_wpc(s,st.wpc);
-        }  
+        } else {
+          nvs_close(handle);
+          return ret;
+        }
         ret = nvs_get_u8(handle,CAMERA_PIXFORMAT_NVS_KEY,&pf);
         if (ret == ESP_OK) {
           s->set_pixformat(s,pf);

--- a/driver/camera.c
+++ b/driver/camera.c
@@ -1593,3 +1593,13 @@ esp_err_t esp_camera_load_from_nvs(const char *key)
       return ret;
   }
 }
+
+esp_err_t esp_camera_enable_xclk(const camera_config_t* config) 
+{
+    return camera_enable_out_clock(config);
+}
+
+void esp_camera_disable_xclk() 
+{
+    camera_disable_out_clock();
+}

--- a/driver/include/esp_camera.h
+++ b/driver/include/esp_camera.h
@@ -187,6 +187,12 @@ esp_err_t esp_camera_save_to_nvs(const char *key);
  */
 esp_err_t esp_camera_load_from_nvs(const char *key);
 
+// Enable camera clock
+esp_err_t esp_camera_enable_xclk(const camera_config_t* config);
+
+// Diseble camera clock
+void esp_camera_disable_xclk();
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
nvs_get_u8 may succeed even if nvs_get_blob failed, and the function would return ESP_OK. It should return error in that case.