### PR TITLE
Fix "periph_module_enable" not found in ESP-IDF v5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,18 +68,6 @@ jobs:
       with:
         path: 'examples'
 
-  build-release-v4_4:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout repo
-      uses: actions/checkout@v2
-      with:
-        submodules: 'recursive'
-    - name: esp-idf build
-      uses: espressif/esp-idf-ci-action@release-v4.4
-      with:
-        path: 'examples'
-
   build-release-v3_3:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,18 @@ jobs:
       with:
         path: 'examples'
 
+  build-release-v4_4:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
+    - name: esp-idf build
+      uses: espressif/esp-idf-ci-action@release-v4.4
+      with:
+        path: 'examples'
+
   build-release-v3_3:
     runs-on: ubuntu-latest
     steps:

--- a/target/private_include/ll_cam.h
+++ b/target/private_include/ll_cam.h
@@ -35,6 +35,10 @@
 #include "freertos/task.h"
 #include "freertos/semphr.h"
 
+#if __has_include("esp_private/periph_ctrl.h")
+# include "esp_private/periph_ctrl.h"
+#endif
+
 #define CAMERA_DBG_PIN_ENABLE 0
 #if CAMERA_DBG_PIN_ENABLE
     #if CONFIG_IDF_TARGET_ESP32


### PR DESCRIPTION
Fixes: https://github.com/espressif/esp32-camera/issues/332