### PR TITLE
bugfix:ov7725 vsync get frame failed

### DIFF
--- a/sensors/ov7670.c
+++ b/sensors/ov7670.c
@@ -45,7 +45,7 @@ static struct regval_list ov7670_default_regs[] = {
 	{CLKRC, 0x00},  
 	{DBLV,  0x4A},  
 
-    {COM10, COM10_VSYNC_NEG | COM10_PCLK_MASK},
+    {COM10, COM10_VSYNC_NEG | COM10_PCLK_FREE},
 
     /* Improve white balance */ 
 	{COM4, 0x40},  

--- a/sensors/ov7725.c
+++ b/sensors/ov7725.c
@@ -59,10 +59,10 @@ static const uint8_t default_regs[][2] = {
     {COM8,          0xF0},
     {COM6,          0xC5},
     {COM9,          0x11},
-    {COM10,         COM10_VSYNC_NEG | COM10_PCLK_MASK}, //Invert VSYNC and MASK PCLK
+    {COM10,         COM10_VSYNC_NEG | COM10_PCLK_FREE}, //Invert VSYNC and MASK PCLK
     {BDBASE,        0x7F},
     {DBSTEP,        0x03},
-    {AEW,           0x96},
+    {AEW,           0x75},
     {AEB,           0x64},
     {VPT,           0xA1},
     {EXHCL,         0x00},


### PR DESCRIPTION
When I use OV7725 and OV7670, I can't get the image. This pr modifies the VSYNC register of OV7725 7670, and the image can be obtained normally, and the white balance is adjusted to make the obtained image normal.