### PR TITLE
Silence unused variable warnings

### DIFF
--- a/sensors/gc0308.c
+++ b/sensors/gc0308.c
@@ -184,6 +184,8 @@ static int set_framesize(sensor_t *sensor, framesize_t framesize)
     uint16_t h = resolution[framesize].height;
     uint16_t row_s = (resolution[FRAMESIZE_VGA].height - h) / 2;
     uint16_t col_s = (resolution[FRAMESIZE_VGA].width - w) / 2;
+    (void)row_s;
+    (void)col_s;
 
 #if CONFIG_GC_SENSOR_SUBSAMPLE_MODE
     struct subsample_cfg {

--- a/sensors/gc2145.c
+++ b/sensors/gc2145.c
@@ -190,6 +190,8 @@ static int set_framesize(sensor_t *sensor, framesize_t framesize)
     uint16_t h = resolution[framesize].height;
     uint16_t row_s = (resolution[FRAMESIZE_UXGA].height - h) / 2;
     uint16_t col_s = (resolution[FRAMESIZE_UXGA].width - w) / 2;
+    (void)row_s;
+    (void)col_s;
 
 #if CONFIG_GC_SENSOR_SUBSAMPLE_MODE
     struct subsample_cfg {


### PR DESCRIPTION
Depending on selected configuration, these may end up being unused and will cause warnings to be emitted on each recompile.