### PR TITLE
Add sccb freq option in menuconfig

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -74,6 +74,14 @@ menu "Camera configuration"
 
     endchoice
 
+    config SCCB_CLK_FREQ
+    int "SCCB clk frequency"
+    default 100000
+    range 100000 400000
+    help
+        Increasing this value can reduce the initialization time of the sensor.
+        Please refer to the relevant instructions of the sensor to adjust the value.
+    
     choice GC_SENSOR_WINDOW_MODE
         bool "GalaxyCore Sensor Window Mode"
         depends on (GC2145_SUPPORT || GC032A_SUPPORT || GC0308_SUPPORT)

--- a/driver/sccb.c
+++ b/driver/sccb.c
@@ -25,13 +25,13 @@ static const char* TAG = "sccb";
 
 #include "driver/i2c.h"
 
-#define SCCB_FREQ               100000           /*!< I2C master frequency*/
-#define WRITE_BIT               I2C_MASTER_WRITE /*!< I2C master write */
-#define READ_BIT                I2C_MASTER_READ  /*!< I2C master read */
-#define ACK_CHECK_EN            0x1              /*!< I2C master will check ack from slave*/
-#define ACK_CHECK_DIS           0x0              /*!< I2C master will not check ack from slave */
-#define ACK_VAL                 0x0              /*!< I2C ack value */
-#define NACK_VAL                0x1              /*!< I2C nack value */
+#define SCCB_FREQ               CONFIG_SCCB_CLK_FREQ  /*!< I2C master frequency*/
+#define WRITE_BIT               I2C_MASTER_WRITE      /*!< I2C master write */
+#define READ_BIT                I2C_MASTER_READ       /*!< I2C master read */
+#define ACK_CHECK_EN            0x1                   /*!< I2C master will check ack from slave*/
+#define ACK_CHECK_DIS           0x0                   /*!< I2C master will not check ack from slave */
+#define ACK_VAL                 0x0                   /*!< I2C ack value */
+#define NACK_VAL                0x1                   /*!< I2C nack value */
 #if CONFIG_SCCB_HARDWARE_I2C_PORT1
 const int SCCB_I2C_PORT         = 1;
 #else


### PR DESCRIPTION
- In some scenarios, we need to initialize the camera sensor quickly. For example, take a few pictures after waking up from sleep mode.
- The PR adds an option to set the sclk of sccb to improve sensor initialization time.