### PR TITLE
XCLK psuedo 'clock dither' for EMI purposes

### DIFF
--- a/driver/include/esp_camera.h
+++ b/driver/include/esp_camera.h
@@ -113,6 +113,8 @@ typedef struct {
     int pin_pclk;                   /*!< GPIO pin for camera PCLK line */
 
     int xclk_freq_hz;               /*!< Frequency of XCLK signal, in Hz. EXPERIMENTAL: Set to 16MHz on ESP32-S2 or ESP32-S3 to enable EDMA mode */
+    int xclk_2nd_freq_hz;           /*!< Frequency of the XCLK can be changed after each image is taken, this will allow a pseudo clock-dither to
+                                         occur on the xclk signal, if not required then leave as 0 */
 
     ledc_timer_t ledc_timer;        /*!< LEDC timer to be used for generating XCLK  */
     ledc_channel_t ledc_channel;    /*!< LEDC channel to be used for generating XCLK  */
@@ -205,6 +207,8 @@ esp_err_t esp_camera_save_to_nvs(const char *key);
  * @param key   A unique nvs key name for the camera settings 
  */
 esp_err_t esp_camera_load_from_nvs(const char *key);
+
+esp_err_t esp_camera_change_xclk_speed(uint32_t clk_speed);
 
 #ifdef __cplusplus
 }

--- a/driver/private_include/xclk.h
+++ b/driver/private_include/xclk.h
@@ -7,3 +7,5 @@ esp_err_t xclk_timer_conf(int ledc_timer, int xclk_freq_hz);
 esp_err_t camera_enable_out_clock();
 
 void camera_disable_out_clock();
+
+esp_err_t camera_change_clock_freq(uint32_t clk_freq);

--- a/target/xclk.c
+++ b/target/xclk.c
@@ -62,3 +62,8 @@ void camera_disable_out_clock()
 {
     ledc_stop(LEDC_LOW_SPEED_MODE, g_ledc_channel, 0);
 }
+
+esp_err_t camera_change_clock_freq(uint32_t clk_freq)
+{
+    return ledc_set_freq(LEDC_LOW_SPEED_MODE, g_ledc_channel, clk_freq);
+}


### PR DESCRIPTION
This pull request allows the user to add a 2nd frequency for the XCLK, this will change after each image is taken. This feature is used to reduce quasi-peak EMI during radiated EMI testing. If the user has a particularly resonant frequency on the PCB design. Other techniques to reduce EMI are adding RC filters to XCLK and PCLK lines.