### PR TITLE
feat: add an option to enlarge default jpeg buf size

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -132,5 +132,15 @@ menu "Camera configuration"
         help
             Maximum value of DMA buffer
             Larger values may fail to allocate due to insufficient contiguous memory blocks, and smaller value may cause DMA interrupt to be too frequent
+    
+    config JPEG_FORMAT_EXTRA_BUFFER_SIZE
+        int "JPEG format extra buffer size"
+        range 0 9999999
+        default 0
+        help
+            When JPEG format is used, the default size of frame buffer is (wight*hight\5).
+            In some cases, the default frame buffer may not have enough space to hold all data.
+            This option could be used to increase the size of frame buffer to (wight*hight\5 + JPEG_FORMAT_EXTRA_BUFFER_SIZE).
+            It is recommended that you first use a large space to obtain the image, and then update the value according to the actual size of the image.
 
 endmenu

--- a/driver/cam_hal.c
+++ b/driver/cam_hal.c
@@ -365,7 +365,7 @@ esp_err_t cam_config(const camera_config_t *config, framesize_t frame_size, uint
     cam_obj->height = resolution[frame_size].height;
 
     if(cam_obj->jpeg_mode){
-        cam_obj->recv_size = cam_obj->width * cam_obj->height / 5;
+        cam_obj->recv_size = cam_obj->width * cam_obj->height / 5 + CONFIG_JPEG_FORMAT_EXTRA_BUFFER_SIZE;
         cam_obj->fb_size = cam_obj->recv_size;
     } else {
         cam_obj->recv_size = cam_obj->width * cam_obj->height * cam_obj->in_bytes_per_pixel;


### PR DESCRIPTION
When JPEG format is used, the default frame buffer may not have enough space to hold all image data.  
The PR adds an option to enlarge the size of the frame buffer.