### PR TITLE
Fix for issue-364: gpio_ll_iomux_in error with idf v5.0

### DIFF
--- a/target/esp32/ll_cam.c
+++ b/target/esp32/ll_cam.c
@@ -37,7 +37,7 @@ static inline int gpio_ll_get_level(gpio_dev_t *hw, int gpio_num)
 #if (ESP_IDF_VERSION_MAJOR >= 5)
 #define GPIO_PIN_INTR_POSEDGE GPIO_INTR_POSEDGE
 #define GPIO_PIN_INTR_NEGEDGE GPIO_INTR_NEGEDGE
-#define gpio_matrix_in(a,b,c) gpio_iomux_in(a,b)
+#include "rom/gpio.h"
 #endif
 
 static const char *TAG = "esp32 ll_cam";

--- a/target/esp32s2/ll_cam.c
+++ b/target/esp32s2/ll_cam.c
@@ -24,7 +24,7 @@
 #if (ESP_IDF_VERSION_MAJOR >= 5)
 #define GPIO_PIN_INTR_POSEDGE GPIO_INTR_POSEDGE
 #define GPIO_PIN_INTR_NEGEDGE GPIO_INTR_NEGEDGE
-#define gpio_matrix_in(a,b,c) gpio_iomux_in(a,b)
+#include "rom/gpio.h"
 #endif
 
 static const char *TAG = "s2 ll_cam";

--- a/target/esp32s3/ll_cam.c
+++ b/target/esp32s3/ll_cam.c
@@ -24,8 +24,7 @@
 #include "cam_hal.h"
 
 #if (ESP_IDF_VERSION_MAJOR >= 5)
-#define gpio_matrix_in(a,b,c) gpio_iomux_in(a,b)
-#define gpio_matrix_out(a,b,c,d) gpio_iomux_out(a,b,c)
+#include "rom/gpio.h"
 #endif
 
 static const char *TAG = "s3 ll_cam";


### PR DESCRIPTION
I removed the gpio_matrix_in define which used gpio_iomux_in.

gpio_iomux_in treats GPIO56 as a real GPIO pin and fail because this pin doesn't exists.  gpio_iomux_in is unable to fix a signal to a 1/0 level, but gpio_matrix_in can with special magic GPIO number2, like GPIO56.  I searched, and found that with v5, you need to include "rom/gpio.h" to get access to this function.

This will address [Issue 364](https://github.com/espressif/esp32-camera/issues/364)