### PR TITLE
Change the fb buffer as 16 bytes aligned

### DIFF
--- a/driver/cam_hal.c
+++ b/driver/cam_hal.c
@@ -296,7 +296,13 @@ static esp_err_t cam_dma_config(const camera_config_t *config)
         cam_obj->frames[x].fb_offset = 0;
         cam_obj->frames[x].en = 0;
         ESP_LOGI(TAG, "Allocating %d Byte frame buffer in %s", alloc_size, _caps & MALLOC_CAP_SPIRAM ? "PSRAM" : "OnBoard RAM");
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 3, 0)
+        // In IDF v4.2 and earlier, memory returned by heap_caps_aligned_alloc must be freed using heap_caps_aligned_free.
+        // And heap_caps_aligned_free is deprecated on v4.3.
+        cam_obj->frames[x].fb.buf = (uint8_t *)heap_caps_aligned_alloc(16, alloc_size, _caps);
+#else
         cam_obj->frames[x].fb.buf = (uint8_t *)heap_caps_malloc(alloc_size, _caps);
+#endif
         CAM_CHECK(cam_obj->frames[x].fb.buf != NULL, "frame buffer malloc failed", ESP_FAIL);
         if (cam_obj->psram_mode) {
             //align PSRAM buffer. TODO: save the offset so proper address can be freed later


### PR DESCRIPTION
The 128 bit aligned buffer have good performance for [esp_jpeg](https://github.com/espressif/esp-adf-libs/blob/master/esp_codec/include/codec/esp_jpeg_enc.h) encoding.  The aligned data to improve the memory load time, combined with esp32-S3 128bit SIMD instructions optimization, we got about 10 fps on OV3660 camera with YUV422 and  VGA.
