### PR TITLE
ov3660 format control register comments is wrong

### DIFF
--- a/sensors/private_include/ov3660_settings.h
+++ b/sensors/private_include/ov3660_settings.h
@@ -289,7 +289,7 @@ static const DRAM_ATTR uint16_t sensor_fmt_yuv422[][2] = {
 
 static const DRAM_ATTR uint16_t sensor_fmt_rgb565[][2] = {
     {FORMAT_CTRL, 0x01}, // RGB
-    {FORMAT_CTRL00, 0x61}, // RGB565 (BGR)
+    {FORMAT_CTRL00, 0x61}, // RGB565 (RGB)
     {REGLIST_TAIL, 0x00}
 };
 


### PR DESCRIPTION
The ov3660 0x4300=0x61 is RGB order, not BGR. Not correct comments easy to make user confuse. I note the ov5640 have same issue, but no sensor to check that.