### PR TITLE
When PSRAM is used as DMA buffer, handle invalid data in cache

### DIFF
--- a/target/private_include/ll_cam.h
+++ b/target/private_include/ll_cam.h
@@ -79,7 +79,9 @@ typedef struct {
     uint8_t en;
     //for RGB/YUV modes
     lldesc_t *dma;
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4, 3, 0)
     size_t fb_offset;
+#endif
 } cam_frame_t;
 
 typedef struct {


### PR DESCRIPTION
When PSRAM is used as DMA buffer, CACHE is not processed. This will cause the CPU to directly access the previously cached wrong data from the CACHE when accessing the image data. At the same time, if the CPU modifies the data in the picture space, dirty data will be stored in the CACHE. These dirty data may trigger writeback after the picture space is used as a DMA buffer, resulting in an error in the final picture data in PSRAM.