### PR TITLE
fix: remove unnecessary new line in logs of driver initialization

### DIFF
--- a/driver/sccb.c
+++ b/driver/sccb.c
@@ -56,7 +56,7 @@ int SCCB_Init(int pin_sda, int pin_scl)
 
     sccb_i2c_port = SCCB_I2C_PORT_DEFAULT;
     sccb_owns_i2c_port = true;
-    ESP_LOGI(TAG, "sccb_i2c_port=%d\n", sccb_i2c_port);
+    ESP_LOGI(TAG, "sccb_i2c_port=%d", sccb_i2c_port);
 
     conf.mode = I2C_MODE_MASTER;
     conf.sda_io_num = pin_sda;


### PR DESCRIPTION
There is a single (unnecessary ) new line in logs of driver initialization and it makes me uncomfortable:
```
I (2715) gpio: GPIO[25]| InputEn: 1| OutputEn: 0| OpenDrain: 0| Pullup: 1| Pulldown: 0| Intr:2
I (2725) cam_hal: cam init ok
I (2725) sccb: pin_sda 26 pin_scl 27
I (2725) sccb: sccb_i2c_port=1

I (2735) gpio: GPIO[32]| InputEn: 0| OutputEn: 1| OpenDrain: 0| Pullup: 0| Pulldown: 0| Intr:0
I (2775) camera: Detected camera at address=0x30
I (2775) camera: Detected OV2640 camera
I (2775) camera: Camera PID=0x26 VER=0x42 MIDL=0x7f MIDH=0xa2
I (2865) cam_hal: buffer_size: 32768, half_buffer_size: 4096, node_buffer_size: 2048, node_cnt: 16, total_cnt: 93
I (2865) cam_hal: Allocating 384000 Byte frame buffer in PSRAM
I (2865) cam_hal: Allocating 384000 Byte frame buffer in PSRAM
I (2875) cam_hal: Allocating 384000 Byte frame buffer in PSRAM
I (2875) cam_hal: Allocating 384000 Byte frame buffer in PSRAM
I (2885) cam_hal: cam config ok
I (2885) ov2640: Set PLL: clk_2x: 0, clk_div: 0, pclk_auto: 0, pclk_div: 12
I (2985) ov2640: Set PLL: clk_2x: 0, clk_div: 0, pclk_auto: 0, pclk_div: 12
```

This PR removes it. Actually you don't have to merge this, just make it disappear in other commit if you want to.