### PR TITLE
Uninstalls ISR service on cam deinit

### DIFF
--- a/target/esp32/ll_cam.c
+++ b/target/esp32/ll_cam.c
@@ -253,7 +253,7 @@ esp_err_t ll_cam_deinit(cam_obj_t *cam)
         esp_intr_free(cam->cam_intr_handle);
         cam->cam_intr_handle = NULL;
     }
-
+    gpio_uninstall_isr_service();
     return ESP_OK;
 }
 

--- a/target/esp32s2/ll_cam.c
+++ b/target/esp32s2/ll_cam.c
@@ -95,7 +95,7 @@ esp_err_t ll_cam_deinit(cam_obj_t *cam)
         esp_intr_free(cam->cam_intr_handle);
         cam->cam_intr_handle = NULL;
     }
-
+    gpio_uninstall_isr_service();
     return ESP_OK;
 }
 


### PR DESCRIPTION
Since `gpio_install_isr_service()` is called when initializing the camera, but on de-initiazlization the ISR service is not uninstalled. This causes an error `gpio_install_isr_service(410): GPIO isr service already installed` when the camera is re-initialized.