### PR TITLE
fix error cam_hal: Failed to get the frame on time!

### DIFF
--- a/driver/esp_camera.c
+++ b/driver/esp_camera.c
@@ -356,7 +356,7 @@ esp_err_t esp_camera_deinit()
     return ret;
 }
 
-#define FB_GET_TIMEOUT (4000 / portTICK_PERIOD_MS)
+#define FB_GET_TIMEOUT  portMAX_DELAY
 
 camera_fb_t *esp_camera_fb_get()
 {


### PR DESCRIPTION
Unable to use the camera other than with the take_picture.c example which included a hard coded 5 second delay.   Changed the FB_GET_TIMEOUT to match portMAX_DELAY

change was proposed as solution to problem with esp-who code examples running on many boards.  Part of the solution was to change the FB_GET_TIMEOUT as it was too short.

combined with: 
https://github.com/espressif/esp-who/pull/250

will fix these issues:
https://github.com/espressif/esp32-camera/issues/488
https://github.com/espressif/esp-who/issues/249