### PR TITLE
Build fix: Add `tjpgd.h` header include for esp32c2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        idf_target: ["esp32", "esp32s2", "esp32s3"]
+        idf_target: ["esp32", "esp32s2", "esp32s3", "esp32c2"]
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         idf_ver: ["release-v5.0"]
-        idf_target: ["esp32", "esp32s2", "esp32s3"]
+        idf_target: ["esp32", "esp32s2", "esp32s3", "esp32c2"]
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2

--- a/conversions/esp_jpg_decode.c
+++ b/conversions/esp_jpg_decode.c
@@ -25,6 +25,8 @@
 #include "esp32c3/rom/tjpgd.h"
 #elif CONFIG_IDF_TARGET_ESP32H2
 #include "esp32h2/rom/tjpgd.h"
+#elif CONFIG_IDF_TARGET_ESP32C2
+#include "esp32c2/rom/tjpgd.h"
 #else
 #error Target CONFIG_IDF_TARGET is not supported
 #endif


### PR DESCRIPTION
1. Fix build error caused because tjpgd.h not included in `esp_jpg_decode.c`
2. Extended CI build for esp32c2 on `IDF >= v5.0`