### PR TITLE
Fix: Make sure there is a queue size of at least 1.

### DIFF
--- a/driver/cam_hal.c
+++ b/driver/cam_hal.c
@@ -383,7 +383,11 @@ esp_err_t cam_config(const camera_config_t *config, framesize_t frame_size, uint
     ret = cam_dma_config(config);
     CAM_CHECK_GOTO(ret == ESP_OK, "cam_dma_config failed", err);
 
-    cam_obj->event_queue = xQueueCreate(cam_obj->dma_half_buffer_cnt - 1, sizeof(cam_event_t));
+    size_t queue_size = cam_obj->dma_half_buffer_cnt - 1;
+    if (queue_size == 0) {
+        queue_size = 1;
+    }
+    cam_obj->event_queue = xQueueCreate(queue_size, sizeof(cam_event_t));
     CAM_CHECK_GOTO(cam_obj->event_queue != NULL, "event_queue create failed", err);
 
     size_t frame_buffer_queue_len = cam_obj->frame_cnt;


### PR DESCRIPTION
We get a crash caused by a failing assert when we use the following config.  In particular we see the crash when using Grayscale and 96x96 resolution.   The platform is ESP32-S3 using PSRAM.  We traced it to cam_hal.c attempting to create a queue of size 0.  This PR has a change where we make sure the queue size is at least 1.   This fixes our case, but maybe there's a more elegant or robust way of fixing it.

```
  config.ledc_channel  = LEDC_CHANNEL_0;
  config.ledc_timer    = LEDC_TIMER_0;
  config.pin_d0        = CAMERA_PIN_D0;
  config.pin_d1        = CAMERA_PIN_D1;
  config.pin_d2        = CAMERA_PIN_D2;
  config.pin_d3        = CAMERA_PIN_D3;
  config.pin_d4        = CAMERA_PIN_D4;
  config.pin_d5        = CAMERA_PIN_D5;
  config.pin_d6        = CAMERA_PIN_D6;
  config.pin_d7        = CAMERA_PIN_D7;
  config.pin_xclk      = CAMERA_PIN_XCLK;
  config.pin_pclk      = CAMERA_PIN_PCLK;
  config.pin_vsync     = CAMERA_PIN_VSYNC;
  config.pin_href      = CAMERA_PIN_HREF;
  config.pin_sccb_sda  = -1; // CAMERA_PIN_SIOD;
  config.pin_sccb_scl  = -1; // CAMERA_PIN_SIOC;
  config.sccb_i2c_port = 0;
  config.pin_pwdn      = CAMERA_PIN_PWDN;
  config.pin_reset     = CAMERA_PIN_RESET;
  config.xclk_freq_hz  = XCLK_FREQ_HZ;
  config.pixel_format  = PIXFORMAT_GRAYSCALE;
  config.frame_size    = FRAMESIZE_96X96;
  config.jpeg_quality  = 12;
  config.fb_count      = 2;
  config.fb_location   = CAMERA_FB_IN_PSRAM;
  config.grab_mode     = CAMERA_GRAB_LATEST;
```
