### PR TITLE
Fails with ESP32 (standard) and ESP-IDF v5.2

### DIFF
--- a/target/esp32/ll_cam.c
+++ b/target/esp32/ll_cam.c
@@ -42,6 +42,9 @@ static inline int gpio_ll_get_level(gpio_dev_t *hw, int gpio_num)
 #define GPIO_PIN_INTR_POSEDGE GPIO_INTR_POSEDGE
 #define GPIO_PIN_INTR_NEGEDGE GPIO_INTR_NEGEDGE
 #define gpio_matrix_in(a,b,c) esp_rom_gpio_connect_in_signal(a,b,c)
+#endif
+
+#ifndef ets_delay_us
 #define ets_delay_us esp_rom_delay_us
 #endif
 

--- a/target/esp32/ll_cam.c
+++ b/target/esp32/ll_cam.c
@@ -42,6 +42,7 @@ static inline int gpio_ll_get_level(gpio_dev_t *hw, int gpio_num)
 #define GPIO_PIN_INTR_POSEDGE GPIO_INTR_POSEDGE
 #define GPIO_PIN_INTR_NEGEDGE GPIO_INTR_NEGEDGE
 #define gpio_matrix_in(a,b,c) esp_rom_gpio_connect_in_signal(a,b,c)
+#define ets_delay_us esp_rom_delay_us
 #endif
 
 static const char *TAG = "esp32 ll_cam";

--- a/target/xclk.c
+++ b/target/xclk.c
@@ -22,8 +22,11 @@ esp_err_t xclk_timer_conf(int ledc_timer, int xclk_freq_hz)
     timer_conf.duty_resolution = LEDC_TIMER_1_BIT;
     timer_conf.freq_hz = xclk_freq_hz;
     timer_conf.speed_mode = LEDC_LOW_SPEED_MODE;
+
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)   
     timer_conf.deconfigure = false;
-    
+#endif
+   
 #if ESP_IDF_VERSION_MAJOR >= 4
     timer_conf.clk_cfg = LEDC_AUTO_CLK;
 #endif

--- a/target/xclk.c
+++ b/target/xclk.c
@@ -22,7 +22,8 @@ esp_err_t xclk_timer_conf(int ledc_timer, int xclk_freq_hz)
     timer_conf.duty_resolution = LEDC_TIMER_1_BIT;
     timer_conf.freq_hz = xclk_freq_hz;
     timer_conf.speed_mode = LEDC_LOW_SPEED_MODE;
-
+    timer_conf.deconfigure = false;
+    
 #if ESP_IDF_VERSION_MAJOR >= 4
     timer_conf.clk_cfg = LEDC_AUTO_CLK;
 #endif


### PR DESCRIPTION
With IDF 5.2 master it works with esp32-s3 but fails with esp32 standard, and has two problems:

First is that when compiling it does not find the function: ets_delay_us'. implicit declaration of function 'ets_delay_us';

Second that it fails to initialize xlock.
camera_xclk: ledc_timer_config failed, rc=103

The solution is to add #define ets_delay_us esp_rom_delay_us when the idf version is greater than 5 and initialize the variable timer_conf.deconfigure = false;