### PR TITLE
Fixed bug caused by new ESP-IDF update

### DIFF
--- a/target/xclk.c
+++ b/target/xclk.c
@@ -27,6 +27,7 @@ esp_err_t xclk_timer_conf(int ledc_timer, int xclk_freq_hz)
     timer_conf.clk_cfg = LEDC_AUTO_CLK;
 #endif
     timer_conf.timer_num = (ledc_timer_t)ledc_timer;
+    timer_conf.deconfigure = false;
     esp_err_t err = ledc_timer_config(&timer_conf);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "ledc_timer_config failed for freq %d, rc=%x", xclk_freq_hz, err);


### PR DESCRIPTION
Updated xclk.c file adding initialization for 'deconfigure' parameter in timer_config struct, fixing a bug with new ESP-IDF core introduced with https://github.com/espressif/esp-idf/commit/64aec54308d8565b1f26ebf193a771eef53953a9 commit. Indeed that commit added 'deconfigure' parameter for the first time causing a bug in the ledc initialization. 
I want to clarify that this is an unreleased version of the esp-idf core, the latest version of master branch. It's my first pull request, let me know if it's useful.

PS: there is another new bug in the i2c initialization of the camera, but i still haven't resolved it. Thanks