### PR TITLE
Support new resolution 800x480

### DIFF
--- a/driver/include/sensor.h
+++ b/driver/include/sensor.h
@@ -91,6 +91,7 @@ typedef enum {
     FRAMESIZE_CIF,      // 400x296
     FRAMESIZE_HVGA,     // 480x320
     FRAMESIZE_VGA,      // 640x480
+    FRAMESIZE_800X480,  // 800x480
     FRAMESIZE_SVGA,     // 800x600
     FRAMESIZE_XGA,      // 1024x768
     FRAMESIZE_HD,       // 1280x720

--- a/driver/sensor.c
+++ b/driver/sensor.c
@@ -29,6 +29,7 @@ const resolution_info_t resolution[FRAMESIZE_INVALID] = {
     {  400,  296, ASPECT_RATIO_4X3   }, /* CIF   */
     {  480,  320, ASPECT_RATIO_3X2   }, /* HVGA  */
     {  640,  480, ASPECT_RATIO_4X3   }, /* VGA   */
+    {  800,  480, ASPECT_RATIO_5X3   }, /* 800x480  */
     {  800,  600, ASPECT_RATIO_4X3   }, /* SVGA  */
     { 1024,  768, ASPECT_RATIO_4X3   }, /* XGA   */
     { 1280,  720, ASPECT_RATIO_16X9  }, /* HD    */


### PR DESCRIPTION
Application Scenarios:

Lots of middle or low-end Video Dollbell products choose a 4-inch 800*480 screen (maybe easier to get vendors), please consider supporting this resolution in esp32-camera. Which will be helpful for such applications.

I have tested it with OV2640, which works well under the resolution.