### PR TITLE
Fix usec frame timestamp

### DIFF
--- a/driver/cam_hal.c
+++ b/driver/cam_hal.c
@@ -94,7 +94,7 @@ static bool cam_start_frame(int * frame_pos)
             ll_cam_do_vsync(cam_obj);
             uint64_t us = (uint64_t)esp_timer_get_time();
             cam_obj->frames[*frame_pos].fb.timestamp.tv_sec = us / 1000000UL;
-            cam_obj->frames[*frame_pos].fb.timestamp.tv_usec = us % 1000000UL;
+            cam_obj->frames[*frame_pos].fb.timestamp.tv_usec = us;
             return true;
         }
     }


### PR DESCRIPTION
When _.timestamp.tv_usec_ used for fps calculation, like this:
```
fps = (1.0/(pic->timestamp.tv_usec - last_frame_ts)*1000000.0);
ESP_LOGI("camera", "fps:%lf", fps);
last_frame_ts = pic->timestamp.tv_usec;
```
Every second, console shows that fps is zero. Basically in cam_hal.c: 
```
cam_obj->frames[*frame_pos].fb.timestamp.tv_usec = us % 1000000UL;
```
%1000000 cause us_timestamp "reset to zero" every 1000000 us.
Removing %1000000 fixed issue.