### PR TITLE
Fixed platformio/arduino build.

### DIFF
--- a/target/xclk.c
+++ b/target/xclk.c
@@ -10,8 +10,8 @@
 #include "esp32-hal-log.h"
 #else
 #include "esp_log.h"
-static const char* TAG = "camera_xclk";
 #endif
+static const char* TAG = "camera_xclk";
 
 #define NO_CAMERA_LEDC_CHANNEL 0xFF
 static ledc_channel_t g_ledc_channel = NO_CAMERA_LEDC_CHANNEL;
@@ -23,10 +23,10 @@ esp_err_t xclk_timer_conf(int ledc_timer, int xclk_freq_hz)
     timer_conf.freq_hz = xclk_freq_hz;
     timer_conf.speed_mode = LEDC_LOW_SPEED_MODE;
 
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)   
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)
     timer_conf.deconfigure = false;
 #endif
-   
+
 #if ESP_IDF_VERSION_MAJOR >= 4
     timer_conf.clk_cfg = LEDC_AUTO_CLK;
 #endif


### PR DESCRIPTION
When building in PlatformIO using this `ini` file:

```ini
[env:esp32cam]
platform = espressif32
board = esp32cam
framework = arduino
build_flags = -I conf
    -DCORE_DEBUG_LEVEL=4
    -I.pio/libdeps/esp32cam/esp32-camera/target/private_include
    -I.pio/libdeps/esp32cam/esp32-camera/driver/private_include
lib_deps =
    espressif/esp32-camera@^2.0.4
build_src_filter =
    +<../.pio/libdeps/esp32cam/esp32-camera/target/esp32/ll_cam.c>
    +<../.pio/libdeps/esp32cam/esp32-camera/target/xclk.c>
```

The build fails with this error:

```text
Processing esp32cam (platform: espressif32; board: esp32cam; framework: arduino)
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Verbose mode can be enabled via `-v, --verbose` option
CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32cam.html
PLATFORM: Espressif 32 (6.5.0) > AI Thinker ESP32-CAM
HARDWARE: ESP32 240MHz, 320KB RAM, 4MB Flash
DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
PACKAGES: 
 - framework-arduinoespressif32 @ 3.20014.231204 (2.0.14) 
 - tool-esptoolpy @ 1.40501.0 (4.5.1) 
 - toolchain-xtensa-esp32 @ 8.4.0+2021r2-patch5
LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
LDF Modes: Finder ~ chain, Compatibility ~ soft
Found 33 compatible libraries
Scanning dependencies...
No dependencies
Building in release mode
Compiling .pio/build/esp32cam/.pio/libdeps/esp32cam/esp32-camera/target/esp32/ll_cam.c.o
Compiling .pio/build/esp32cam/.pio/libdeps/esp32cam/esp32-camera/target/xclk.c.o
Building .pio/build/esp32cam/bootloader.bin
Generating partitions .pio/build/esp32cam/partitions.bin
In file included from .pio/libdeps/esp32cam/esp32-camera/target/xclk.c:10:
.pio/libdeps/esp32cam/esp32-camera/target/xclk.c: In function 'xclk_timer_conf':
.pio/libdeps/esp32cam/esp32-camera/target/xclk.c:32:18: error: 'TAG' undeclared (first use in this function)
         ESP_LOGE(TAG, "ledc_timer_config failed for freq %d, rc=%x", xclk_freq_hz, err);
                  ^~~
/home/real/.platformio/packages/framework-arduinoespressif32/cores/esp32/esp32-hal-log.h:159:72: note: in definition of macro 'log_e'
 #define log_e(format, ...) log_printf(ARDUHAL_LOG_FORMAT(E, format), ##__VA_ARGS__)
                                                                        ^~~~~~~~~~~
.pio/libdeps/esp32cam/esp32-camera/target/xclk.c:32:9: note: in expansion of macro 'ESP_LOGE'
         ESP_LOGE(TAG, "ledc_timer_config failed for freq %d, rc=%x", xclk_freq_hz, err);
         ^~~~~~~~
.pio/libdeps/esp32cam/esp32-camera/target/xclk.c:32:18: note: each undeclared identifier is reported only once for each function it appears in
         ESP_LOGE(TAG, "ledc_timer_config failed for freq %d, rc=%x", xclk_freq_hz, err);
                  ^~~
/home/real/.platformio/packages/framework-arduinoespressif32/cores/esp32/esp32-hal-log.h:159:72: note: in definition of macro 'log_e'
 #define log_e(format, ...) log_printf(ARDUHAL_LOG_FORMAT(E, format), ##__VA_ARGS__)
                                                                        ^~~~~~~~~~~
.pio/libdeps/esp32cam/esp32-camera/target/xclk.c:32:9: note: in expansion of macro 'ESP_LOGE'
         ESP_LOGE(TAG, "ledc_timer_config failed for freq %d, rc=%x", xclk_freq_hz, err);
         ^~~~~~~~
.pio/libdeps/esp32cam/esp32-camera/target/xclk.c: In function 'camera_enable_out_clock':
.pio/libdeps/esp32cam/esp32-camera/target/xclk.c:41:18: error: 'TAG' undeclared (first use in this function)
         ESP_LOGE(TAG, "ledc_timer_config failed, rc=%x", err);
                  ^~~
/home/real/.platformio/packages/framework-arduinoespressif32/cores/esp32/esp32-hal-log.h:159:72: note: in definition of macro 'log_e'
 #define log_e(format, ...) log_printf(ARDUHAL_LOG_FORMAT(E, format), ##__VA_ARGS__)
                                                                        ^~~~~~~~~~~
.pio/libdeps/esp32cam/esp32-camera/target/xclk.c:41:9: note: in expansion of macro 'ESP_LOGE'
         ESP_LOGE(TAG, "ledc_timer_config failed, rc=%x", err);
         ^~~~~~~~
esptool.py v4.5.1
Creating esp32 image...
Merged 1 ELF section
Successfully created esp32 image.
Compiling .pio/build/esp32cam/FrameworkArduino/Esp.cpp.o
Compiling .pio/build/esp32cam/FrameworkArduino/FirmwareMSC.cpp.o
Compiling .pio/build/esp32cam/FrameworkArduino/FunctionalInterrupt.cpp.o
Compiling .pio/build/esp32cam/FrameworkArduino/HWCDC.cpp.o
Compiling .pio/build/esp32cam/FrameworkArduino/HardwareSerial.cpp.o
Compiling .pio/build/esp32cam/FrameworkArduino/IPAddress.cpp.o
Compiling .pio/build/esp32cam/FrameworkArduino/IPv6Address.cpp.o
Compiling .pio/build/esp32cam/FrameworkArduino/MD5Builder.cpp.o
Compiling .pio/build/esp32cam/FrameworkArduino/Print.cpp.o
Compiling .pio/build/esp32cam/FrameworkArduino/Stream.cpp.o
Compiling .pio/build/esp32cam/FrameworkArduino/StreamString.cpp.o
Compiling .pio/build/esp32cam/FrameworkArduino/Tone.cpp.o
Compiling .pio/build/esp32cam/FrameworkArduino/USB.cpp.o
Compiling .pio/build/esp32cam/FrameworkArduino/USBCDC.cpp.o
Compiling .pio/build/esp32cam/FrameworkArduino/USBMSC.cpp.o
Compiling .pio/build/esp32cam/FrameworkArduino/WMath.cpp.o
Compiling .pio/build/esp32cam/FrameworkArduino/WString.cpp.o
Compiling .pio/build/esp32cam/FrameworkArduino/base64.cpp.o
Compiling .pio/build/esp32cam/FrameworkArduino/cbuf.cpp.o
Compiling .pio/build/esp32cam/FrameworkArduino/esp32-hal-adc.c.o
*** [.pio/build/esp32cam/.pio/libdeps/esp32cam/esp32-camera/target/xclk.c.o] Error 1
========================================================================================== [FAILED] Took 1.40 seconds ==========================================================================================

 *  The terminal process "platformio 'run', '--environment', 'esp32cam'" terminated with exit code: 1. 
 *  Terminal will be reused by tasks, press any key to close it. 
```

This PR fixes the problem.

