### PR TITLE
Add option to customize JPEG mode frame size in menuconfig

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -179,6 +179,33 @@ menu "Camera configuration"
             Maximum value of DMA buffer
             Larger values may fail to allocate due to insufficient contiguous memory blocks, and smaller value may cause DMA interrupt to be too frequent.
 
+    choice CAMERA_JPEG_MODE_FRAME_SIZE_OPTION
+        prompt "JPEG mode frame size option"
+        default CAMERA_JPEG_MODE_FRAME_SIZE_AUTO
+        help
+            Select whether to use automatic calculation for JPEG mode frame size or specify a custom value.
+
+        config CAMERA_JPEG_MODE_FRAME_SIZE_AUTO
+            bool "Use automatic calculation (width * height / 5)"
+            help
+                Use the default calculation for JPEG mode frame size.
+                Note: In very low resolutions like QQVGA, the default calculation tends to result in insufficient buffer size.
+
+        config CAMERA_JPEG_MODE_FRAME_SIZE_CUSTOM
+            bool "Specify custom frame size"
+            help
+                Specify a custom frame size in bytes for JPEG mode.
+
+    endchoice
+
+    config CAMERA_JPEG_MODE_FRAME_SIZE
+        int "Custom JPEG mode frame size (bytes)"
+        default 8192
+        depends on CAMERA_JPEG_MODE_FRAME_SIZE_CUSTOM
+        help
+            This option sets the custom frame size in JPEG mode.
+            Specify the desired buffer size in bytes.
+
     config CAMERA_CONVERTER_ENABLED
         bool "Enable camera RGB/YUV converter"
         depends on IDF_TARGET_ESP32S3

--- a/driver/cam_hal.c
+++ b/driver/cam_hal.c
@@ -374,7 +374,11 @@ esp_err_t cam_config(const camera_config_t *config, framesize_t frame_size, uint
     cam_obj->height = resolution[frame_size].height;
 
     if(cam_obj->jpeg_mode){
+#ifdef CONFIG_CAMERA_JPEG_MODE_FRAME_SIZE_AUTO
         cam_obj->recv_size = cam_obj->width * cam_obj->height / 5;
+#else
+        cam_obj->recv_size = CONFIG_CAMERA_JPEG_MODE_FRAME_SIZE;
+#endif
         cam_obj->fb_size = cam_obj->recv_size;
     } else {
         cam_obj->recv_size = cam_obj->width * cam_obj->height * cam_obj->in_bytes_per_pixel;


### PR DESCRIPTION
This Pull Request provides an option in menuconfig to customize the buffer size for JPEG mode, addressing [Issue #663](https://github.com/espressif/esp32-camera/issues/663).

* Added a configurable option in Kconfig to choose between the default automatic calculation (width * height / 5) and specifying a custom buffer size.
* The default setting maintains the existing behavior, so it should not affect current code. However, please review carefully as I am not very experienced with this library.


