### PR TITLE
fix(xclk): Zero init ledc_channel_config_t for forward compatibility

### DIFF
--- a/target/xclk.c
+++ b/target/xclk.c
@@ -47,7 +47,7 @@ esp_err_t camera_enable_out_clock(const camera_config_t* config)
     }
 
     g_ledc_channel = config->ledc_channel;
-    ledc_channel_config_t ch_conf;
+    ledc_channel_config_t ch_conf = {0};
     ch_conf.gpio_num = config->pin_xclk;
     ch_conf.speed_mode = LEDC_LOW_SPEED_MODE;
     ch_conf.channel = config->ledc_channel;


### PR DESCRIPTION
## Description

LEDC driver was extended in https://github.com/espressif/esp-idf/commit/4a90deb2278322e6c605484770caafebfbbc615f with new config structure members. We must zero init the config struct to get default behavior.


## Related
* Needed because of https://github.com/espressif/esp-idf/commit/4a90deb2278322e6c605484770caafebfbbc615f

## Testing

Run esp32-camera example on S2 board.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
