### PR TITLE
Fixes missing return error code validation during camera initialization

### DIFF
--- a/driver/cam_hal.c
+++ b/driver/cam_hal.c
@@ -362,7 +362,8 @@ esp_err_t cam_config(const camera_config_t *config, framesize_t frame_size, uint
     esp_err_t ret = ESP_OK;
 
     ret = ll_cam_set_sample_mode(cam_obj, (pixformat_t)config->pixel_format, config->xclk_freq_hz, sensor_pid);
-
+    CAM_CHECK_GOTO(ret == ESP_OK, "ll_cam_set_sample_mode failed", err);
+    
     cam_obj->jpeg_mode = config->pixel_format == PIXFORMAT_JPEG;
 #if CONFIG_IDF_TARGET_ESP32
     cam_obj->psram_mode = false;


### PR DESCRIPTION
## Description

Add missing error code validation in cam_hal.

## Related

Fixes #699
