### PR TITLE
Remove instruction to call camera_probe

### DIFF
--- a/driver/include/esp_camera.h
+++ b/driver/include/esp_camera.h
@@ -178,8 +178,6 @@ typedef struct {
 /**
  * @brief Initialize the camera driver
  *
- * @note call camera_probe before calling this function
- *
  * This function detects and configures camera over I2C interface,
  * allocates framebuffer and DMA buffers,
  * initializes parallel I2S input, and sets up DMA descriptors.


### PR DESCRIPTION
## Description

Cleanup: remove instruction to call camera_probe from the documentation for esp_camera_init. camera_probe is not a public function. Actually, esp_camera_init calls camera_probe, so the documentation is backwards.

## Testing

Comment-only change.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [X] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.
