### PR TITLE
Add error handling for esp_jpg_decode

### DIFF
--- a/conversions/esp_jpg_decode.c
+++ b/conversions/esp_jpg_decode.c
@@ -114,11 +114,17 @@ esp_err_t esp_jpg_decode(size_t len, jpg_scale_t scale, jpg_reader_cb reader, jp
     uint16_t output_height = decoder.height / (1 << (uint8_t)(jpeg.scale));
 
     //output start
-    writer(arg, 0, 0, output_width, output_height, NULL);
+    if (!writer(arg, 0, 0, output_width, output_height, NULL)) {
+        ESP_LOGE(TAG, "JPG Writer Start Failed!");
+        return ESP_FAIL;
+    }
     //output write
     jres = jd_decomp(&decoder, _jpg_write, (uint8_t)jpeg.scale);
     //output end
-    writer(arg, output_width, output_height, output_width, output_height, NULL);
+    if (!writer(arg, output_width, output_height, output_width, output_height, NULL)) {
+        ESP_LOGE(TAG, "JPG Writer End Failed!");
+        return ESP_FAIL;
+    }
 
     if (jres != JDR_OK) {
         ESP_LOGE(TAG, "JPG Decompression Failed! %s", jd_errors[jres]);

--- a/conversions/to_bmp.c
+++ b/conversions/to_bmp.c
@@ -78,8 +78,10 @@ static bool _rgb_write(void * arg, uint16_t x, uint16_t y, uint16_t w, uint16_t 
             jpeg->height = h;
             //if output is null, this is BMP
             if(!jpeg->output){
-                jpeg->output = (uint8_t *)_malloc((w*h*3)+jpeg->data_offset);
+                size_t out_size = (w*h*3)+jpeg->data_offset;
+                jpeg->output = (uint8_t *)_malloc(out_size);
                 if(!jpeg->output){
+                    ESP_LOGE(TAG, "_malloc failed! %zu", out_size);
                     return false;
                 }
             }
@@ -121,8 +123,10 @@ static bool _rgb565_write(void * arg, uint16_t x, uint16_t y, uint16_t w, uint16
             jpeg->height = h;
             //if output is null, this is BMP
             if(!jpeg->output){
-                jpeg->output = (uint8_t *)_malloc((w*h*3)+jpeg->data_offset);
+                size_t out_size = (w*h*3)+jpeg->data_offset;
+                jpeg->output = (uint8_t *)_malloc(out_size);
                 if(!jpeg->output){
+                    ESP_LOGE(TAG, "_malloc failed! %zu", out_size);
                     return false;
                 }
             }


### PR DESCRIPTION

<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description
esp_jpg_decode does not return if writer fails, causing unhandled exceptions. Also logs when rgb_write malloc fails.

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
