### PR TITLE
contrast fixes

### DIFF
--- a/sensors/gc0308.c
+++ b/sensors/gc0308.c
@@ -279,7 +279,8 @@ static int set_framesize(sensor_t *sensor, framesize_t framesize)
 
 static int set_contrast(sensor_t *sensor, int contrast)
 {
-    if (contrast != 0) {
+    if (contrast > 0) {
+        sensor->status.contrast = contrast;
         write_reg(sensor->slv_addr, 0xfe, 0x00);
         write_reg(sensor->slv_addr, 0xb3, contrast);
     }
@@ -370,7 +371,7 @@ static int init_status(sensor_t *sensor)
 {
     write_reg(sensor->slv_addr, 0xfe, 0x00);
     sensor->status.brightness = 0;
-    sensor->status.contrast = 0;
+    sensor->status.contrast = 50;
     sensor->status.saturation = 0;
     sensor->status.sharpness = 0;
     sensor->status.denoise = 0;


### PR DESCRIPTION
1. update sensor->status.contrast when setting contrast (consistent with most other settings like hmirror)
2. initialize sensor->status.contrast to the actual default (50) rather than 0, which is invalid
3. Ignore attempts to set negative contrast values, not just 0
