### PR TITLE
fix(cam_hal): guard cam_verify_jpeg_eoi() against buffer-underflow

### DIFF
--- a/driver/cam_hal.c
+++ b/driver/cam_hal.c
@@ -46,6 +46,7 @@ static cam_obj_t *cam_obj = NULL;
 static const uint8_t JPEG_SOI_MARKER[] = {0xFF, 0xD8, 0xFF}; /* SOI = FF D8 FF */
 #define JPEG_SOI_MARKER_LEN (3)
 static const uint16_t JPEG_EOI_MARKER = 0xD9FF;              /* EOI = FF D9 */
+#define JPEG_EOI_MARKER_LEN (2)
 
 static int cam_verify_jpeg_soi(const uint8_t *inbuf, uint32_t length)
 {
@@ -66,10 +67,14 @@ static int cam_verify_jpeg_soi(const uint8_t *inbuf, uint32_t length)
 
 static int cam_verify_jpeg_eoi(const uint8_t *inbuf, uint32_t length)
 {
+    if (length < JPEG_EOI_MARKER_LEN) {
+        return -1;
+    }
+
     int offset = -1;
-    uint8_t *dptr = (uint8_t *)inbuf + length - 2;
+    uint8_t *dptr = (uint8_t *)inbuf + length - JPEG_EOI_MARKER_LEN;
     while (dptr > inbuf) {
-        if (memcmp(dptr, &JPEG_EOI_MARKER, 2) == 0) {
+        if (memcmp(dptr, &JPEG_EOI_MARKER, JPEG_EOI_MARKER_LEN) == 0) {
             offset = dptr - inbuf;
             //ESP_LOGW(TAG, "EOI: %d", length - (offset + 2));
             return offset;


### PR DESCRIPTION
## Description

If DMA returns a frame shorter than two bytes, the previous code did:

    dptr = inbuf + length - 2;

which under-flows the pointer and produces undefined behaviour.

Behaviour for valid frames (length ≥ 2) is unchanged; damaged or empty buffers are now discarded safely.


## Related

In the search for the cause of crashes reported by @turenkomv here: https://github.com/esphome/esphome/pull/8832#issuecomment-2897275655 I found this underflow of a pointer, which can cause undefined behaviour.

## Testing

@turenkomv would you be so kind and would test this on your hardware? Tag is `fixes_for_m5_0.2`, which is the currently used version in ESPHome with both patches on top.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass. (?)
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
