### PR TITLE
fix: Remove unused Kconfig option

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -130,8 +130,6 @@ menu "Camera configuration"
         help
             Enable this option if you want to use the HM0360.
             Disable this option to save memory.
-            
-    config SCCB_I2C_PORT
 
     config MEGA_CCM_SUPPORT
         bool "Support MEGA CCM 5MP"


### PR DESCRIPTION
Remove unused configurations in Kconfig to prevent build warnings.