### PR TITLE
cam_hal: shrink ISR stack, silence spam, strip logs at low levels

### DIFF
--- a/driver/cam_hal.c
+++ b/driver/cam_hal.c
@@ -42,13 +42,21 @@
 static const char *TAG = "cam_hal";
 static cam_obj_t *cam_obj = NULL;
 
-static const uint32_t JPEG_SOI_MARKER = 0xFFD8FF;  // written in little-endian for esp32
-static const uint16_t JPEG_EOI_MARKER = 0xD9FF;  // written in little-endian for esp32
+/* JPEG markers in little-endian order (ESP32). */
+static const uint8_t JPEG_SOI_MARKER[] = {0xFF, 0xD8, 0xFF}; /* SOI = FF D8 FF */
+static const uint16_t JPEG_EOI_MARKER = 0xD9FF;              /* EOI = FF D9 */
 
 static int cam_verify_jpeg_soi(const uint8_t *inbuf, uint32_t length)
 {
-    for (uint32_t i = 0; i < length; i++) {
-        if (memcmp(&inbuf[i], &JPEG_SOI_MARKER, 3) == 0) {
+    const size_t soi_len = sizeof(JPEG_SOI_MARKER);
+
+    if (length < soi_len) {
+        ESP_LOGW(TAG, "NO-SOI");
+        return -1;
+    }
+
+    for (uint32_t i = 0; i <= length - soi_len; i++) {
+        if (memcmp(&inbuf[i], JPEG_SOI_MARKER, soi_len) == 0) {
             //ESP_LOGW(TAG, "SOI: %d", (int) i);
             return i;
         }

--- a/driver/cam_hal.c
+++ b/driver/cam_hal.c
@@ -67,10 +67,14 @@ static int cam_verify_jpeg_soi(const uint8_t *inbuf, uint32_t length)
 
 static int cam_verify_jpeg_eoi(const uint8_t *inbuf, uint32_t length)
 {
+    if (length < sizeof(JPEG_EOI_MARKER)) {
+        return -1;
+    }
+
     int offset = -1;
-    uint8_t *dptr = (uint8_t *)inbuf + length - 2;
+    uint8_t *dptr = (uint8_t *)inbuf + length - sizeof(JPEG_EOI_MARKER);
     while (dptr > inbuf) {
-        if (memcmp(dptr, &JPEG_EOI_MARKER, 2) == 0) {
+        if (memcmp(dptr, &JPEG_EOI_MARKER, sizeof(JPEG_EOI_MARKER)) == 0) {
             offset = dptr - inbuf;
             //ESP_LOGW(TAG, "EOI: %d", length - (offset + 2));
             return offset;


### PR DESCRIPTION
## Description

**Requires #758, #759 and #760 to be merged first, thus containing their commits here.**

* Replace ESP_LOGx in ISRs/tight loops with CAM_WARN_THROTTLE(counter,msg)
  → uses ROM-resident ets_printf(); ~300 B less stack per hit.
* At CONFIG_LOG_DEFAULT_LEVEL < 2 the macro compiles to a no-op,
  so *all* warning code is dropped from the binary.
* First miss logs immediately, then every 100th; counter wraps at 10 000
  (reset to 1 to skip the “first miss” banner after wrap).
* New static uint16_t counters per call-site keep totals without globals.
* switch CAM_LOG_SPAM_EVERY_FRAME (=0) restores old per-frame debug.

No functional change to capture path—just less stack, fewer cycles,
smaller image, and a much quieter UART.


## Related

Crashes reported by @turenkomv [here](https://github.com/esphome/esphome/pull/8832#issuecomment-2897275655) due to excessive stack usage.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
