### PR TITLE
hm0360: harden _set_pll() against read-failures & bad widths, silence unused-param warnings

### DIFF
--- a/sensors/hm0360.c
+++ b/sensors/hm0360.c
@@ -358,7 +358,12 @@ static int _set_pll(sensor_t *sensor, int bypass, int multiplier, int sys_div, i
         value = 0x00;
     }
 
-    pll_cfg = read_reg(sensor->slv_addr, PLL1CFG);
+    int ret = read_reg(sensor->slv_addr, PLL1CFG);
+    if (ret < 0) {
+        return ret;
+    }
+
+    pll_cfg = (uint8_t)ret;
     return write_reg(sensor->slv_addr, PLL1CFG, (pll_cfg & 0xFC) | value);
 }
 

--- a/sensors/hm0360.c
+++ b/sensors/hm0360.c
@@ -6,6 +6,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <errno.h>
 #include "sccb.h"
 #include "xclk.h"
 #include "hm0360.h"
@@ -345,6 +346,14 @@ static int set_xclk(sensor_t *sensor, int timer, int xclk)
 
 static int _set_pll(sensor_t *sensor, int bypass, int multiplier, int sys_div, int root_2x, int pre_div, int seld5, int pclk_manual, int pclk_div)
 {
+    (void)bypass;
+    (void)multiplier;
+    (void)sys_div;
+    (void)root_2x;
+    (void)pre_div;
+    (void)seld5;
+    (void)pclk_manual;
+    (void)pclk_div;
     uint8_t value = 0;
     uint8_t pll_cfg = 0;
 
@@ -361,6 +370,14 @@ static int _set_pll(sensor_t *sensor, int bypass, int multiplier, int sys_div, i
     int ret = read_reg(sensor->slv_addr, PLL1CFG);
     if (ret < 0) {
         return ret;
+    }
+    if (ret > 0xFF) {
+        /*
+         * Guard against unexpected wide register values. If read_reg
+         * ever returns a 16-bit result, reject values that don't fit
+         * in a single byte to avoid truncation.
+         */
+        return -ERANGE;
     }
 
     pll_cfg = (uint8_t)ret;


### PR DESCRIPTION


## Description

This pull-request eliminates the corner-case in the HM0360 driver where a failed SCCB/I²C read could silently corrupt the sensor’s PLL configuration, and it tidies up related compiler noise.

#### Rationale

* `read_reg()` returns a negative error on bus failure.
  Previously `_set_pll()` copied that raw `int` into an 8-bit variable and wrote it back to **PLL1CFG**, so any error (e.g. `-1 → 0xFF`) overwrote the register while the function still reported 'success'.
* `read_reg()` return data is checked for the data width. If 16-bit data is supplied it's no longer truncated to 8 bit and instead an error is returned.
* Extra PLL parameters are currently unused and triggered `-Wunused-parameter` warnings.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
