### PR TITLE
hm1055: fix set_brightness error handling & logging

### DIFF
--- a/sensors/hm1055.c
+++ b/sensors/hm1055.c
@@ -449,8 +449,11 @@ static int set_brightness(sensor_t *sensor, int level)
 
     ispctrl5 |= 0x40; // enable brightness
     ret = write_reg(sensor->slv_addr, ISPCTRL5, ispctrl5);
-    ret = write_reg(sensor->slv_addr, BRIGHT, brightness);
-    if (ret != 0)
+    if (ret == 0)
+    {
+        ret = write_reg(sensor->slv_addr, BRIGHT, brightness);
+    }
+    if (ret == 0)
     {
         ESP_LOGD(TAG, "Set brightness to: %d", level);
         sensor->status.brightness = level;


### PR DESCRIPTION
## Description

The old code always wrote BRIGHT even if enabling ISPCTRL5 failed, while also overwriting the first error code. It also used `if (ret != 0)` to log/update status, so we reported success when the write actually failed.

Guard the BRIGHT write behind a successful ISPCTRL5 write and only log / update `sensor->status.brightness` when both writes succeed. This keeps the original error, and prevents false success reports.

## Testing

I don't own the hardware.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
