### PR TITLE
sccb-ng: fix off-by-one device capacity check to prevent overflow

### DIFF
--- a/driver/sccb-ng.c
+++ b/driver/sccb-ng.c
@@ -80,7 +80,7 @@ int SCCB_Install_Device(uint8_t slv_addr)
     esp_err_t ret;
     i2c_master_bus_handle_t bus_handle;
 
-    if (device_count > MAX_DEVICES)
+    if (device_count >= MAX_DEVICES)
     {
         ESP_LOGE(TAG, "cannot add more than %d devices", MAX_DEVICES);
         return ESP_FAIL;


### PR DESCRIPTION
## Description

SCCB_Install_Device() rejected new devices only when device_count > MAX_DEVICES. When device_count == MAX_DEVICES the function still proceeded to install the device and wrote to devices[device_count], i.e. devices[MAX_DEVICES], which is one element past the end of the devices[] array (valid indices 0..MAX_DEVICES-1).

This off-by-one results in a buffer overflow / write outside the designated memory area and then increments device_count to MAX_DEVICES+1.

Change the guard to `device_count >= MAX_DEVICES` so we refuse installation once the array is full and prevent the out-of-bounds write/read chain.


## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
