### PR TITLE
fix jpeg soi check for psram_mode (DMA)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ if(IDF_TARGET STREQUAL "esp32" OR IDF_TARGET STREQUAL "esp32s2" OR IDF_TARGET ST
       )
   endif()
 
-  set(priv_requires freertos nvs_flash)
+  set(priv_requires freertos nvs_flash esp_mm)
 
   set(min_version_for_esp_timer "4.2")
   if (idf_version VERSION_GREATER_EQUAL min_version_for_esp_timer)


### PR DESCRIPTION
## Description

- Added a configurable probe length for PSRAM JPEG validation via CAM_SOI_PROBE_BYTES
- For PSRAM mode, CAM_SOI_PROBE_BYTES is copied from the first DMA block into a stack buffer and validated by cam_verify_jpeg_soi() to verify that it's a valid jpeg image before continuing the capture.
- Reading from PSRAM directly with cam_verify_jpeg_soi() is here avoided due to latency of small operations done by cam_verify_jpeg_soi().

## Related

Related #775

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
