### PR TITLE
cam_hal: drop caches for psram_mode frames before hand-off to application

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ if(IDF_TARGET STREQUAL "esp32" OR IDF_TARGET STREQUAL "esp32s2" OR IDF_TARGET ST
       )
   endif()
 
-  set(priv_requires freertos nvs_flash)
+  set(priv_requires freertos nvs_flash esp_mm)
 
   set(min_version_for_esp_timer "4.2")
   if (idf_version VERSION_GREATER_EQUAL min_version_for_esp_timer)


### PR DESCRIPTION
## Description

Invalidate data-cache lines for the image captured via dma (in psram_mode)
before the buffer is handed off to the application. This ensures the the
CPU will read the correct data from the PSRAM instead of cached segments
from the previous image stored in this buffer.

Other work:

- The cache invalidation was refactored into `cam_drop_psram_cache()`

Performance consideration:

On an ESP32-S3 @ 240 MHz with 32-byte cache lines:

```
|------------------------------------------------|
| Image size | Lines flushed | Cycles | Time |
|------------|---------------|--------|----------|
|100 KiB | 3 200 | 16 000 |  66.7 µs |
|300 KiB | 9 600 | 48 000 | 200   µs |
|________________________________________________|
``` 

## Related

PR https://github.com/espressif/esp32-camera/pull/777, PR https://github.com/espressif/esp32-camera/pull/776 <-- **both mandatory to be merged first, therefore this PR contains their commits atm.**

Bug: https://github.com/espressif/esp32-camera/issues/775

## Testing

Not yet tested in hardware.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
