### PR TITLE
fix build error

### DIFF
--- a/target/esp32/ll_cam.c
+++ b/target/esp32/ll_cam.c
@@ -16,6 +16,8 @@
 #include <string.h>
 #include "soc/i2s_struct.h"
 #include "esp_idf_version.h"
+#include "driver/gpio.h"
+
 #if (ESP_IDF_VERSION_MAJOR >= 4) && (ESP_IDF_VERSION_MINOR > 1)
 #include "hal/gpio_ll.h"
 #else

--- a/target/esp32s2/ll_cam.c
+++ b/target/esp32s2/ll_cam.c
@@ -20,6 +20,7 @@
 #include "ll_cam.h"
 #include "xclk.h"
 #include "cam_hal.h"
+#include "driver/gpio.h"
 
 #if (ESP_IDF_VERSION_MAJOR >= 4) && (ESP_IDF_VERSION_MINOR >= 3)
 #include "esp_rom_gpio.h"

--- a/target/esp32s3/ll_cam.c
+++ b/target/esp32s3/ll_cam.c
@@ -25,6 +25,7 @@
 #include "ll_cam.h"
 #include "cam_hal.h"
 #include "esp_rom_gpio.h"
+#include "driver/gpio.h"
 
 #if (ESP_IDF_VERSION_MAJOR >= 5)
 #include "soc/gpio_sig_map.h"


### PR DESCRIPTION
## Description
fix build error,  ll_cam.c miss driver/gpio.h include.

```sh
cd esp32-camera/examples/camera_example/
idf.py clean set-target esp32 build
idf.py clean set-target esp32s2 build
idf.py clean set-target esp32s3 build
```

```txt
esp32-camera/target/esp32/ll_cam.c:254:5: error: implicit declaration of function 'gpio_isr_handler_remove' [-Wimplicit-function-declaration]
  254 |     gpio_isr_handler_remove(cam->vsync_pin);
      |     ^~~~~~~~~~~~~~~~~~~~~~~
esp32-camera/target/esp32/ll_cam.c: In function 'll_cam_vsync_intr_enable':
esp32-camera/target/esp32/ll_cam.c:334:9: error: implicit declaration of function 'gpio_intr_enable'; did you mean 'esp_intr_enable'? [-Wimplicit-function-declaration]
  334 |         gpio_intr_enable(cam->vsync_pin);
      |         ^~~~~~~~~~~~~~~~
      |         esp_intr_enable
esp32-camera/target/esp32/ll_cam.c:336:9: error: implicit declaration of function 'gpio_intr_disable'; did you mean 'esp_intr_disable'? [-Wimplicit-function-declaration]
  336 |         gpio_intr_disable(cam->vsync_pin);
      |         ^~~~~~~~~~~~~~~~~
      |         esp_intr_disable
esp32-camera/target/esp32/ll_cam.c: In function 'll_cam_set_pin':
esp32-camera/target/esp32/ll_cam.c:342:5: error: unknown type name 'gpio_config_t'; did you mean 'esp_log_config_t'?
  342 |     gpio_config_t io_conf = {0};
      |     ^~~~~~~~~~~~~
      |     esp_log_config_t
esp32-camera/target/esp32/ll_cam.c:343:12: error: request for member 'intr_type' in something not a structure or union
```

## Related

ll_cam.c miss driver/gpio.h include.
```c
#include "driver/gpio.h"
```


## Testing

esp32 && esp32s2 && esp32s3  all build success.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
