### PR TITLE
cam_hal: psram: reset DMA and yield after NO-EOI to resume capture

### DIFF
--- a/driver/cam_hal.c
+++ b/driver/cam_hal.c
@@ -597,7 +597,10 @@ camera_fb_t *cam_take(TickType_t timeout)
 
             CAM_WARN_THROTTLE(warn_eoi_miss_cnt,
                               "NO-EOI - JPEG end marker missing");
+            /* Reset DMA so capture can resume after a truncated frame */
+            ll_cam_dma_reset(cam_obj);
             cam_give(dma_buffer);
+            vTaskDelay(1);
             continue; /* wait for another frame */
         } else if (cam_obj->psram_mode &&
                    cam_obj->in_bytes_per_pixel != cam_obj->fb_bytes_per_pixel) {


### PR DESCRIPTION

## Description

In PSRAM JPEG mode, a truncated frame (missing EOI) could leave GDMA in
a bad state and cause subsequent captures to time out.

Fix:
- On the NO-EOI path, reset the DMA channel (`ll_cam_dma_reset(cam_obj)`).
- Yield once (`vTaskDelay(1)`) to let the pipeline restart cleanly.

Result: the driver recovers on the next frame instead of timing out,
reducing spurious capture failures after truncated JPEGs.


## Testing

Does fix some crashes, but not everything in `psram_mode` with JPEGs.


---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
