### PR TITLE
increase camera task stack size

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -187,7 +187,7 @@ menu "Camera configuration"
 
     config CAMERA_TASK_STACK_SIZE
         int "CAM task stack size"
-        default 2048
+        default 4096
         help
             Camera task stack size
 

--- a/driver/cam_hal.c
+++ b/driver/cam_hal.c
@@ -37,7 +37,7 @@
 #if CONFIG_CAMERA_TASK_STACK_SIZE
 #define CAM_TASK_STACK             CONFIG_CAMERA_TASK_STACK_SIZE
 #else
-#define CAM_TASK_STACK             (2*1024)
+#define CAM_TASK_STACK             (4*1024)
 #endif
 
 static const char *TAG = "cam_hal";


### PR DESCRIPTION

## Description

The small camera stack size of 2048 byte seems to be an issue, so we increase it by default to 4096.

## Related

https://github.com/espressif/arduino-esp32/issues/11672

https://github.com/espressif/arduino-esp32/issues/11674



## Testing

I'm using 8192 for all my testing without any issues.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
