### PR TITLE
align frame buffer with cache lines

### DIFF
--- a/driver/cam_hal.c
+++ b/driver/cam_hal.c
@@ -489,6 +489,10 @@ static esp_err_t cam_dma_config(const camera_config_t *config)
     } else {
         _caps |= MALLOC_CAP_SPIRAM;
     }
+    size_t fb_align = dcache_line_size();
+    if (fb_align == 0) {
+        fb_align = 32;
+    }
     for (int x = 0; x < cam_obj->frame_cnt; x++) {
         cam_obj->frames[x].dma = NULL;
         cam_obj->frames[x].fb_offset = 0;
@@ -497,7 +501,7 @@ static esp_err_t cam_dma_config(const camera_config_t *config)
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 3, 0)
         // In IDF v4.2 and earlier, memory returned by heap_caps_aligned_alloc must be freed using heap_caps_aligned_free.
         // And heap_caps_aligned_free is deprecated on v4.3.
-        cam_obj->frames[x].fb.buf = (uint8_t *)heap_caps_aligned_alloc(16, alloc_size, _caps);
+        cam_obj->frames[x].fb.buf = (uint8_t *)heap_caps_aligned_alloc(fb_align, alloc_size, _caps);
 #else
         cam_obj->frames[x].fb.buf = (uint8_t *)heap_caps_malloc(alloc_size, _caps);
 #endif


### PR DESCRIPTION


## Description

The ESP32, ESP32-C3 and ESP32-C6 always use 32 byte cache lines. The ESP32-S3 can switch between 16, 32 and 64 byte cache lines. The ESP32-S2 can swtich between 16 and 32 byte cache lines.

For all platforms the default is 32 byte.

This change makes sure the frame buffer is always aligned with the current cache line configuration.

In most configurations this change will switch the alignment from 16 byte to 32 byte.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
