### PR TITLE
fix: Define IDF >=5.1 requirement

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -4,6 +4,7 @@ issues: https://github.com/espressif/esp32-camera/issues
 documentation: https://github.com/espressif/esp32-camera/tree/main/README.md
 repository: https://github.com/espressif/esp32-camera.git
 dependencies:
+  idf: ">=5.1"
   esp_jpeg:
     version: "^1.3.0"
     public: true


### PR DESCRIPTION
esp32-camera now depends on esp_mm which was introduced in IDF 5.1.

I suggest releasing new version and yanking 2.1.1 because it breaks 5.0 builds

Follow-up to https://github.com/espressif/esp32-camera/pull/776
