### PR TITLE
Silence HAL logs if logs are disabled

### DIFF
--- a/driver/cam_hal.c
+++ b/driver/cam_hal.c
@@ -40,7 +40,12 @@
 #include "esp32s3/rom/ets_sys.h"
 #endif
 #endif // ESP_IDF_VERSION_MAJOR
-#define ESP_CAMERA_ETS_PRINTF ets_printf
+
+#if CONFIG_LOG_DEFAULT_LEVEL_NONE
+#define ESP_CAMERA_ETS_PRINTF(f, ...)
+#else
+#define ESP_CAMERA_ETS_PRINTF(f, ...) ets_printf(f, ##__VA_ARGS__)
+#endif
 
 #if CONFIG_CAMERA_TASK_STACK_SIZE
 #define CAM_TASK_STACK             CONFIG_CAMERA_TASK_STACK_SIZE


### PR DESCRIPTION
This pull request updates the logging macro definition in `driver/cam_hal.c` to respect the default logging level configuration. The main change ensures that the `ESP_CAMERA_ETS_PRINTF` macro does not output logs when logging is disabled.

Logging configuration improvements:

* Updated the definition of the `ESP_CAMERA_ETS_PRINTF` macro to conditionally disable logging output when `CONFIG_LOG_DEFAULT_LEVEL_NONE` is set, preventing any log messages from being printed in this configuration.

Fixes: https://github.com/espressif/esp32-camera/issues/797