### PR TITLE
fix: ov5640 framesize validation to check FRAMESIZE_5MP

### DIFF
--- a/sensors/ov5640.c
+++ b/sensors/ov5640.c
@@ -384,9 +384,9 @@ static int set_framesize(sensor_t *sensor, framesize_t framesize)
     framesize_t old_framesize = sensor->status.framesize;
     sensor->status.framesize = framesize;
 
-    if(framesize > FRAMESIZE_QSXGA){
-        ESP_LOGE(TAG, "Invalid framesize: %u", framesize);
-        return -1;
+    if (framesize > FRAMESIZE_5MP) {
+        ESP_LOGW(TAG, "Invalid framesize: %u", framesize);
+        framesize = FRAMESIZE_5MP;
     }
     uint16_t w = resolution[framesize].width;
     uint16_t h = resolution[framesize].height;


### PR DESCRIPTION
Change error logging from error to warning for invalid framesize and set framesize to FRAMESIZE_5MP if it exceeds the limit.

<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

OV5640 Sensors actually supporty up to 5MP (2592x1944) - Currently the code limits it  `FRAMESIZE_QSXGA,    // 2560x1920`
<img width="323" height="83" alt="image" src="https://github.com/user-attachments/assets/b373ef08-2a7d-4854-bbdf-be7d0e3e61f3" />

<img width="1050" height="496" alt="image" src="https://github.com/user-attachments/assets/b8e711fc-087c-4b85-8f1f-ed67a61d4563" />



This change is same as the code in [mega_ccm.c](https://github.com/espressif/esp32-camera/blob/master/sensors/mega_ccm.c#L95)

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
