### PR TITLE
Fix compilation of GDMA and periph enable in IDF 6

### DIFF
--- a/target/esp32/ll_cam.c
+++ b/target/esp32/ll_cam.c
@@ -45,6 +45,11 @@ static inline int gpio_ll_get_level(gpio_dev_t *hw, int gpio_num)
 #define gpio_matrix_in(a,b,c) esp_rom_gpio_connect_in_signal(a,b,c)
 #endif
 
+#if (ESP_IDF_VERSION_MAJOR > 5)
+#include "soc/dport_access.h"
+#include "soc/dport_reg.h"
+#endif
+
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 2) 
 #define ets_delay_us esp_rom_delay_us
 #endif
@@ -289,7 +294,12 @@ bool ll_cam_start(cam_obj_t *cam, int frame_pos)
 esp_err_t ll_cam_config(cam_obj_t *cam, const camera_config_t *config)
 {
     // Enable and configure I2S peripheral
+#if ESP_IDF_VERSION_MAJOR > 5
+    DPORT_SET_PERI_REG_MASK(DPORT_PERIP_CLK_EN_REG, DPORT_I2S0_CLK_EN);
+    DPORT_CLEAR_PERI_REG_MASK(DPORT_PERIP_RST_EN_REG, DPORT_I2S0_RST);
+#else
     periph_module_enable(PERIPH_I2S0_MODULE);
+#endif
 
     I2S0.conf.rx_reset = 1;
     I2S0.conf.rx_reset = 0;

--- a/target/esp32s2/ll_cam.c
+++ b/target/esp32s2/ll_cam.c
@@ -33,6 +33,10 @@
 #define ets_delay_us(a) esp_rom_delay_us(a)
 #endif
 
+#if (ESP_IDF_VERSION_MAJOR > 5)
+#include "soc/dport_access.h"
+#endif
+
 static const char *TAG = "s2 ll_cam";
 
 #define I2S_ISR_ENABLE(i) {I2S0.int_clr.i = 1;I2S0.int_ena.i = 1;}
@@ -136,7 +140,12 @@ esp_err_t ll_cam_config(cam_obj_t *cam, const camera_config_t *config)
     if(err != ESP_OK) {
         return err;
     }
+#if ESP_IDF_VERSION_MAJOR > 5
+    DPORT_SET_PERI_REG_MASK(DPORT_PERIP_CLK_EN_REG, DPORT_I2S0_CLK_EN);
+    DPORT_CLEAR_PERI_REG_MASK(DPORT_PERIP_RST_EN0_REG, DPORT_I2S0_RST);
+#else
     periph_module_enable(PERIPH_I2S0_MODULE);
+#endif
     // Configure the clock
     I2S0.clkm_conf.clkm_div_num = 2; // 160MHz / 2 = 80MHz
     I2S0.clkm_conf.clkm_div_b = 0;

--- a/target/esp32s3/ll_cam.c
+++ b/target/esp32s3/ll_cam.c
@@ -18,7 +18,6 @@
 #include "soc/lcd_cam_struct.h"
 #include "soc/lcd_cam_reg.h"
 #include "soc/gdma_struct.h"
-#include "soc/gdma_periph.h"
 #include "soc/gdma_reg.h"
 #include "hal/clk_gate_ll.h"
 #include "esp_private/gdma.h"
@@ -34,6 +33,12 @@
 #define gpio_matrix_in(a,b,c) esp_rom_gpio_connect_in_signal(a,b,c)
 #define gpio_matrix_out(a,b,c,d) esp_rom_gpio_connect_out_signal(a,b,c,d)
 #define ets_delay_us(a) esp_rom_delay_us(a)
+#endif
+
+#if (ESP_IDF_VERSION_MAJOR > 5)
+#include "soc/dport_access.h"
+#else
+#include "soc/gdma_periph.h"
 #endif
 
 #if !defined(SOC_GDMA_PAIRS_PER_GROUP) && defined(SOC_GDMA_PAIRS_PER_GROUP_MAX)
@@ -235,16 +240,20 @@ static esp_err_t ll_cam_dma_init(cam_obj_t *cam)
     //     }
     // }
 
+#if ESP_IDF_VERSION_MAJOR > 5
+    if (!(DPORT_REG_GET_BIT(SYSTEM_PERIP_RST_EN1_REG, SYSTEM_DMA_RST) == 0 &&
+          DPORT_REG_GET_BIT(SYSTEM_PERIP_CLK_EN1_REG, SYSTEM_DMA_CLK_EN) != 0)) {
+        DPORT_CLEAR_PERI_REG_MASK(SYSTEM_PERIP_CLK_EN1_REG, SYSTEM_DMA_CLK_EN);
+        DPORT_SET_PERI_REG_MASK(SYSTEM_PERIP_RST_EN1_REG, SYSTEM_DMA_RST);
+        DPORT_SET_PERI_REG_MASK(SYSTEM_PERIP_CLK_EN1_REG, SYSTEM_DMA_CLK_EN);
+        DPORT_CLEAR_PERI_REG_MASK(SYSTEM_PERIP_RST_EN1_REG, SYSTEM_DMA_RST);
+    }
+#else
     if (!periph_ll_periph_enabled(PERIPH_GDMA_MODULE)) {
         periph_ll_disable_clk_set_rst(PERIPH_GDMA_MODULE);
         periph_ll_enable_clk_clear_rst(PERIPH_GDMA_MODULE);
     }
-    // if (REG_GET_BIT(SYSTEM_PERIP_CLK_EN1_REG, SYSTEM_DMA_CLK_EN) == 0) {
-    //     REG_CLR_BIT(SYSTEM_PERIP_CLK_EN1_REG, SYSTEM_DMA_CLK_EN);
-    //     REG_SET_BIT(SYSTEM_PERIP_CLK_EN1_REG, SYSTEM_DMA_CLK_EN);
-    //     REG_SET_BIT(SYSTEM_PERIP_RST_EN1_REG, SYSTEM_DMA_RST);
-    //     REG_CLR_BIT(SYSTEM_PERIP_RST_EN1_REG, SYSTEM_DMA_RST);
-    // }
+#endif
     ll_cam_dma_reset(cam);
     return ESP_OK;
 }
@@ -405,7 +414,12 @@ esp_err_t ll_cam_set_pin(cam_obj_t *cam, const camera_config_t *config)
 esp_err_t ll_cam_init_isr(cam_obj_t *cam)
 {
 	esp_err_t ret = ESP_OK;
-    ret = esp_intr_alloc_intrstatus(gdma_periph_signals.groups[0].pairs[cam->dma_num].rx_irq_id,
+    ret = esp_intr_alloc_intrstatus(
+#if (ESP_IDF_VERSION_MAJOR > 5)
+                                     ETS_DMA_IN_CH0_INTR_SOURCE + cam->dma_num,
+#else
+                                     gdma_periph_signals.groups[0].pairs[cam->dma_num].rx_irq_id,
+#endif
                                      ESP_INTR_FLAG_LOWMED | ESP_INTR_FLAG_SHARED | CAMERA_ISR_IRAM_FLAG,
                                      (uint32_t)&GDMA.channel[cam->dma_num].in.int_st, GDMA_IN_SUC_EOF_CH0_INT_ST_M,
                                      ll_cam_dma_isr, cam, &cam->dma_intr_handle);


### PR DESCRIPTION
This pull request updates low-level camera driver code for ESP32, ESP32-S2, and ESP32-S3 targets to improve compatibility with ESP-IDF version 5 and above. The changes mainly introduce conditional compilation to handle differences in peripheral clock and reset management APIs between ESP-IDF versions, ensuring the drivers work correctly across multiple ESP-IDF releases.

**ESP-IDF v5+ compatibility improvements:**

* Added conditional includes for `dport_access.h` and `dport_reg.h` in `ll_cam.c` for ESP32 and ESP32-S2, and adjusted peripheral clock/reset handling to use DPORT macros on ESP-IDF v5+ (`target/esp32/ll_cam.c`, `target/esp32s2/ll_cam.c`). [[1]](diffhunk://#diff-0156d7917176219dd52ecdc7a13d3e7f572769721b7166b4d278400237722250R48-R52) [[2]](diffhunk://#diff-031232c2bec5214f610d91ee9d6214c7d4614a1ce9ad6ddca0156797b64b01c1R36-R39)
* Updated `ll_cam_config` functions to use DPORT macros for enabling and resetting the I2S peripheral on ESP-IDF v5+, while retaining the old API for earlier versions (`target/esp32/ll_cam.c`, `target/esp32s2/ll_cam.c`). [[1]](diffhunk://#diff-0156d7917176219dd52ecdc7a13d3e7f572769721b7166b4d278400237722250R297-R302) [[2]](diffhunk://#diff-031232c2bec5214f610d91ee9d6214c7d4614a1ce9ad6ddca0156797b64b01c1R143-R148)

**ESP32-S3 driver enhancements:**

* Adjusted includes and conditional logic for DMA and GDMA peripherals to select appropriate headers and APIs based on ESP-IDF version (`target/esp32s3/ll_cam.c`). [[1]](diffhunk://#diff-733311667eee41d4da2ab2ef6b9ac6a603fcc699074d24a701b17bd48a31f6c3L21) [[2]](diffhunk://#diff-733311667eee41d4da2ab2ef6b9ac6a603fcc699074d24a701b17bd48a31f6c3R38-R43)
* Updated DMA initialization to use DPORT macros for clock and reset on ESP-IDF v5+, and fallback to the older API otherwise (`target/esp32s3/ll_cam.c`).
* Modified interrupt allocation to use the correct interrupt source for DMA on ESP-IDF v5+ (`target/esp32s3/ll_cam.c`).

These changes ensure that the camera drivers remain functional and stable across ESP-IDF version upgrades, particularly with the significant API changes introduced in ESP-IDF v5.

Fixes: https://github.com/espressif/esp32-camera/issues/812