### PR TITLE
Properly set sccb_owns_i2c_port when camera driver is not the owner of…

### DIFF
--- a/driver/sccb-ng.c
+++ b/driver/sccb-ng.c
@@ -152,7 +152,7 @@ int SCCB_Use_Port(int i2c_num)
         return ESP_ERR_INVALID_ARG;
     }
     sccb_i2c_port = i2c_num;
-
+    sccb_owns_i2c_port = false; // in this case, camera doesn't own the i2c port
     return ESP_OK;
 }
 

--- a/driver/sccb.c
+++ b/driver/sccb.c
@@ -81,6 +81,7 @@ int SCCB_Use_Port(int i2c_num) { // sccb use an already initialized I2C port
         return ESP_ERR_INVALID_ARG;
     }
     sccb_i2c_port = i2c_num;
+    sccb_owns_i2c_port = false; // in this case, camera doesn't own the i2c port
     return ESP_OK;
 }
 


### PR DESCRIPTION
## Description

This PR fixes the fact that when using an external i2c handle, the camera driver doesn't own the i2c handle.

## Related

None

## Testing

Tested with Omnivision sensors with a ESP32S3 with IDF 5.4.2 only with the legacy driver. This should also work out for the new i2c driver.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
