### PR TITLE
Add configurable RGB565 byte order support to JPEG encoding

### DIFF
--- a/conversions/include/img_converters.h
+++ b/conversions/include/img_converters.h
@@ -129,6 +129,17 @@ bool fmt2rgb888(const uint8_t *src_buf, size_t src_len, pixformat_t format, uint
 #define JPG_SCALE_MAX  JPEG_IMAGE_SCALE_1_8
 bool jpg2rgb565(const uint8_t *src, size_t src_len, uint8_t * out, esp_jpeg_image_scale_t scale);
 
+/**
+ * @brief Configure RGB565 input byte order for JPEG encoding.
+ *
+ * Controls how RGB565 source pixel data is interpreted before JPEG conversion.
+ * By default, the encoder assumes big-endian byte order (MSB first), which
+ * matches most ESP32 camera and frame buffer outputs.
+ *
+ * @param enable    True to use big-endian RGB565 (default), false for little-endian.
+ */
+void jpgSetRgb565BE(bool enable);
+
 #ifdef __cplusplus
 }
 #endif

--- a/conversions/to_jpg.cpp
+++ b/conversions/to_jpg.cpp
@@ -29,6 +29,8 @@
 static const char* TAG = "to_jpg";
 #endif
 
+static bool rgb565_big_endian = true;
+
 static void *_malloc(size_t size)
 {
     void * res = malloc(size);
@@ -60,9 +62,15 @@ static IRAM_ATTR void convert_line_format(uint8_t * src, pixformat_t format, uin
         l = width * 2;
         src += l * line;
         for(i=0; i<l; i+=2) {
-            dst[o++] = src[i] & 0xF8;
-            dst[o++] = (src[i] & 0x07) << 5 | (src[i+1] & 0xE0) >> 3;
-            dst[o++] = (src[i+1] & 0x1F) << 3;
+            if (rgb565_big_endian) {
+                dst[o++] = src[i] & 0xF8;
+                dst[o++] = (src[i] & 0x07) << 5 | (src[i+1] & 0xE0) >> 3;
+                dst[o++] = (src[i+1] & 0x1F) << 3;
+            } else  {
+                dst[o++] = src[i+1] & 0xF8;
+                dst[o++] = (src[i+1] & 0x07) << 5 | (src[i] & 0xE0) >> 3;
+                dst[o++] = (src[i] & 0x1F) << 3;
+            }
         }
     } else if(format == PIXFORMAT_YUV422) {
         uint8_t y0, y1, u, v;
@@ -232,4 +240,9 @@ bool fmt2jpg(uint8_t *src, size_t src_len, uint16_t width, uint16_t height, pixf
 bool frame2jpg(camera_fb_t * fb, uint8_t quality, uint8_t ** out, size_t * out_len)
 {
     return fmt2jpg(fb->buf, fb->len, fb->width, fb->height, fb->format, quality, out, out_len);
+}
+
+void jpgSetRgb565BE(bool enable)
+{
+    rgb565_big_endian = enable;
 }


### PR DESCRIPTION
## Description

This PR adds support for selecting the byte order when converting RGB565 input to RGB888 in the JPEG encoder. Previously, the encoder always assumed big-endian (MSB-first) RGB565 pixel ordering. This matches most ESP32 camera driver outputs, but does not match some custom frame pipelines and external RGB sources, which instead produce little-endian RGB565.

To support both cases, this PR introduces:

`void jpgSetRgb565BE(bool enable);
`

- true → Big-endian RGB565 (default, existing behavior)
- false → Little-endian RGB565

No existing behavior is changed unless the new function is explicitly used.

### Changes
- Adds jpgSetRgb565BE(bool) function
- Adds internal rgb565_big_endian state flag (default true)
- Updates convert_line_format() to select byte-order at runtime
- No performance impact.


<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing
- Verified BE → unchanged output.
- Verified LE → correct color output in pipelines producing LE RGB565 frames.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [X] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [X] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.
