### PR TITLE
Fix: replace non-standard 'uint' with 'size_t' in to_jpg.cpp

### DIFF
--- a/conversions/to_jpg.cpp
+++ b/conversions/to_jpg.cpp
@@ -188,7 +188,7 @@ protected:
     size_t max_len, index;
 
 public:
-    memory_stream(void *pBuf, uint buf_size) : out_buf(static_cast<uint8_t*>(pBuf)), max_len(buf_size), index(0) { }
+    memory_stream(void *pBuf, size_t buf_size) : out_buf(static_cast<uint8_t*>(pBuf)), max_len(buf_size), index(0) { }
 
     virtual ~memory_stream() { }
 


### PR DESCRIPTION
ESP-IDF 6.0 ships GCC 15 and switches the default C library from Newlib to Picolibc. With Picolibc, `uint` is not defined as an implicit typedef (it's non-standard and was previously provided by `<sys/types.h>` on some platforms).

This causes a compilation error in `conversions/to_jpg.cpp` line 191:

```
error: 'uint' has not been declared; did you mean 'int'?
```

The file does include `jpge.h` which defines `typedef unsigned int uint;`, but that typedef is scoped inside `namespace jpge` and not visible at the point of use (the `memory_stream` class on line 191 is in the global namespace).

Changed to `size_t` to match the type of the `max_len` member that `buf_size` is assigned to.