### PR TITLE
Change log level from warning to debug for read

### DIFF
--- a/driver/sccb-ng.c
+++ b/driver/sccb-ng.c
@@ -243,7 +243,7 @@ uint8_t SCCB_Read(uint8_t slv_addr, uint8_t reg)
     if (ret != ESP_OK) {
         ESP_LOGE(TAG, "SCCB_Read Failed addr:0x%02x, reg:0x%02x, ret:%d", slv_addr, reg, ret);
     }
-    ESP_LOGW(TAG, "read OK");
+    ESP_LOGD(TAG, "read OK");
     return rx_buffer[0];
 }
 


### PR DESCRIPTION
This pull request makes a minor logging adjustment in the `SCCB_Read` function. The log level for a successful read operation has been changed from warning to debug, making the logs less noisy during normal operation.

* Changed the log level from `ESP_LOGW` (warning) to `ESP_LOGD` (debug) for the "read OK" message in `SCCB_Read` in `driver/sccb-ng.c`.