### PR TITLE
Preserve repeated-start SCCB reads with fallback

### DIFF
--- a/driver/sccb-ng.c
+++ b/driver/sccb-ng.c
@@ -227,18 +227,40 @@ uint8_t SCCB_Read(uint8_t slv_addr, uint8_t reg)
 {
     i2c_master_dev_handle_t dev_handle = *(get_handle_from_address(slv_addr));
 
-    uint8_t tx_buffer[1];
-    uint8_t rx_buffer[1];
+    uint8_t tx_buffer[1] = { reg };
+    uint8_t rx_buffer[1] = { 0 };
 
-    tx_buffer[0] = reg;
-
-    esp_err_t ret = i2c_master_transmit_receive(dev_handle, tx_buffer, 1, rx_buffer, 1, TIMEOUT_MS);
-
-    if (ret != ESP_OK)
+    esp_err_t ret = i2c_master_transmit_receive(dev_handle, tx_buffer, sizeof(tx_buffer),
+                                                rx_buffer, sizeof(rx_buffer), TIMEOUT_MS);
+    if (ret == ESP_OK)
     {
-        ESP_LOGE(TAG, "SCCB_Read Failed addr:0x%02x, reg:0x%02x, data:0x%02x, ret:%d", slv_addr, reg, rx_buffer[0], ret);
+        return rx_buffer[0];
     }
 
+    /*
+     * Most SCCB sensors expect an 8-bit register read to use a repeated-start
+     * write/read transaction. Some devices reject that sequence with the new
+     * IDF I2C master driver, so only fall back to a stop/start read after the
+     * repeated-start transaction fails.
+     */
+    ESP_LOGD(TAG, "SCCB_Read repeated-start failed addr:0x%02x, reg:0x%02x, ret:%d; retrying",
+             slv_addr, reg, ret);
+
+    ret = i2c_master_transmit(dev_handle, tx_buffer, sizeof(tx_buffer), TIMEOUT_MS);
+    if (ret != ESP_OK)
+    {
+        ESP_LOGE(TAG, "SCCB_Read addr phase failed addr:0x%02x, reg:0x%02x, ret:%d",
+                 slv_addr, reg, ret);
+        return 0;
+    }
+
+    ret = i2c_master_receive(dev_handle, rx_buffer, sizeof(rx_buffer), TIMEOUT_MS);
+    if (ret != ESP_OK)
+    {
+        ESP_LOGE(TAG, "SCCB_Read data phase failed addr:0x%02x, reg:0x%02x, ret:%d",
+                 slv_addr, reg, ret);
+        return 0;
+    }
 
     return rx_buffer[0];
 }

--- a/driver/sccb-ng.c
+++ b/driver/sccb-ng.c
@@ -228,22 +228,18 @@ uint8_t SCCB_Read(uint8_t slv_addr, uint8_t reg)
     i2c_master_dev_handle_t dev_handle = *(get_handle_from_address(slv_addr));
 
     uint8_t tx_buffer[1];
-    uint8_t rx_buffer[1] = {0};
+    uint8_t rx_buffer[1];
 
     tx_buffer[0] = reg;
 
-    esp_err_t ret = i2c_master_transmit(dev_handle, tx_buffer, 1, TIMEOUT_MS);
+    esp_err_t ret = i2c_master_transmit_receive(dev_handle, tx_buffer, 1, rx_buffer, 1, TIMEOUT_MS);
 
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "SCCB_Read addr phase failed addr:0x%02x, reg:0x%02x, ret:%d", slv_addr, reg, ret);
-        return 0;
+    if (ret != ESP_OK)
+    {
+        ESP_LOGE(TAG, "SCCB_Read Failed addr:0x%02x, reg:0x%02x, data:0x%02x, ret:%d", slv_addr, reg, rx_buffer[0], ret);
     }
 
-    ret = i2c_master_receive(dev_handle, rx_buffer, 1, TIMEOUT_MS);
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "SCCB_Read Failed addr:0x%02x, reg:0x%02x, ret:%d", slv_addr, reg, ret);
-    }
-    ESP_LOGD(TAG, "read OK");
+
     return rx_buffer[0];
 }
 


### PR DESCRIPTION


## Description

- Reverting commit fafc2005d293412d051eed2e8bdaf7a2719bad5e from #828 which caused the regression.
- Preserve repeated-start SCCB reads with fallback

## Related

Fixes #846

## Testing

Tested on ESP32-S3.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
